### PR TITLE
docs: add 3 integration stories (daemon bundling, plugin discovery, health aggregation)

### DIFF
--- a/docs/stories/backend/US-BE-027-daemon-bundling.md
+++ b/docs/stories/backend/US-BE-027-daemon-bundling.md
@@ -1,0 +1,34 @@
+# US-BE-027: Room Daemon Bundling Strategy
+
+**Phase:** 1 (Infrastructure)
+**Priority:** P0 — blocks all WS/REST proxy stories
+
+## User Story
+
+As a **Hive server operator**, I want the room daemon to start automatically when Hive launches, so that I don't need to manage it as a separate process.
+
+## Description
+
+Hive bundles a room daemon instance. This story defines how hive-server starts, monitors, and stops the room daemon process. The daemon provides the real-time messaging infrastructure that all other Hive features depend on.
+
+## Acceptance Criteria
+
+1. hive-server starts room daemon as a child process on startup
+2. Daemon socket path is configured in hive config, not hardcoded
+3. hive-server waits for daemon health endpoint before accepting client connections
+4. If daemon crashes, hive-server logs error and attempts restart (max 3 retries)
+5. On hive-server shutdown, daemon receives SIGTERM with grace period
+6. Daemon data/state dirs are co-located with Hive's data directory
+7. Startup logs show daemon PID and socket path
+
+## Technical Notes
+
+- Use `std::process::Command` to spawn `room daemon` with configured flags
+- Pass `--socket`, `--data-dir`, `--state-dir`, `--ws-port` from Hive config
+- Health check via `GET /api/health` on the daemon's WS port
+- Consider `--persistent` flag to prevent daemon auto-shutdown on idle
+
+## Dependencies
+
+- **Blocks:** US-BE-003 (WS relay), US-BE-004 (REST proxy), US-BE-001 (health)
+- **Blocked by:** none (first thing to implement)

--- a/docs/stories/backend/US-BE-028-plugin-discovery.md
+++ b/docs/stories/backend/US-BE-028-plugin-discovery.md
@@ -1,0 +1,33 @@
+# US-BE-028: Plugin Discovery
+
+**Phase:** 2 (Auth & Agents)
+**Priority:** P1
+
+## User Story
+
+As a **Hive frontend developer**, I want to query which plugins are available in the room daemon, so that I can show available commands and features in the UI.
+
+## Description
+
+Hive needs to know what plugins are loaded by the room daemon (taskboard, queue, stats, agent, and any dynamic plugins). This enables the frontend to show available slash commands, render plugin-specific UI (task boards, queues), and hide features for plugins that aren't installed.
+
+## Acceptance Criteria
+
+1. Hive server exposes `GET /api/plugins` returning a list of loaded plugins
+2. Each plugin entry includes: name, version, commands (name + description + params)
+3. Response includes both builtin and dynamically-loaded plugins
+4. Frontend can use this to populate command palette and feature toggles
+5. Endpoint is cached (plugins don't change at runtime) with 5-min TTL
+6. Returns empty list gracefully if daemon is unreachable
+
+## Technical Notes
+
+- Room daemon already has `room plugin list` CLI command and `/info` slash command
+- Hive can query via REST: `GET /api/<room>/send` with `/info` command, or parse the builtin command infos
+- Alternative: add a dedicated `/api/plugins` endpoint to room daemon (cleaner)
+- Plugin commands drive the frontend command palette (FE-014)
+
+## Dependencies
+
+- **Blocks:** FE-014 (command palette), FE-008 (spawn wizard — needs personality list)
+- **Blocked by:** US-BE-027 (daemon bundling), US-BE-003 (WS relay)

--- a/docs/stories/backend/US-BE-029-health-aggregation.md
+++ b/docs/stories/backend/US-BE-029-health-aggregation.md
@@ -1,0 +1,37 @@
+# US-BE-029: Health Check Aggregation
+
+**Phase:** 1 (Infrastructure)
+**Priority:** P1
+
+## User Story
+
+As a **Hive operator**, I want a single health endpoint that shows the status of all system components, so that I can monitor the entire stack from one place.
+
+## Description
+
+Hive's health endpoint should aggregate health from three sources: the Hive server itself, the bundled room daemon, and spawned agents. This gives operators (and the frontend status bar) a unified view of system health.
+
+## Acceptance Criteria
+
+1. `GET /api/health` returns aggregated status: `ok`, `degraded`, or `down`
+2. Response includes component-level health:
+   - `hive`: server uptime, memory usage
+   - `room`: daemon status (ok/unreachable), connected users count, active rooms
+   - `agents`: total spawned, healthy count, stale count, exited count
+3. Overall status is `ok` only when all components are healthy
+4. Status is `degraded` if agents are stale but room is up
+5. Status is `down` if room daemon is unreachable
+6. Response time < 100ms (cached, not live-queried on every request)
+7. Frontend status bar consumes this endpoint (FE-001 app shell)
+
+## Technical Notes
+
+- Room health via `GET /api/health` on daemon WS port (already exists)
+- Agent health via `/agent list` command data field (already has health column)
+- Cache aggregated result for 10s to avoid hammering daemon on every frontend poll
+- Consider SSE or WS push for real-time health updates (stretch)
+
+## Dependencies
+
+- **Blocks:** FE-001 (app shell status bar)
+- **Blocked by:** US-BE-027 (daemon bundling), US-BE-001 (basic health)


### PR DESCRIPTION
Adds 3 stories identified in the cross-cutting review:
- US-BE-027: Room daemon bundling strategy (P0, blocks all WS/REST stories)
- US-BE-028: Plugin discovery endpoint
- US-BE-029: Health check aggregation (unified hive+room+agents status)

Each includes dependency links to existing stories.