### PR TITLE
docs: clarify BE-001, BE-003, BE-012 with missing specs

### DIFF
--- a/docs/stories/backend/US-BE-001-server-health.md
+++ b/docs/stories/backend/US-BE-001-server-health.md
@@ -18,5 +18,12 @@
 - Use `axum::Router` to register the route
 - Uptime is calculated from a `start_time: std::time::Instant` stored in shared `AppState`
 
+## Clarifications (Sprint 19 Review)
+
+- **Daemon connectivity timeout**: 2 seconds. If the daemon does not respond to a health ping within 2s, report status as `"degraded"`.
+- **Startup behavior**: The health endpoint returns `{"status": "starting"}` until the first successful daemon ping completes. This prevents load balancers from routing traffic before the server has confirmed daemon reachability.
+- **Failure recovery**: After 3 consecutive daemon timeouts (each at the 2s threshold), report `{"status": "unhealthy", "error": "<detail>"}` instead of `"degraded"`. Reset the counter on any successful ping.
+- **Cache TTL**: 5 seconds as specified in technical notes, but invalidate the cached status immediately upon receiving a daemon disconnect event (e.g., WebSocket close or TCP reset). The next health check triggers a fresh probe rather than serving stale `"ok"`.
+
 ## Phase
 Phase 1 (Skeleton + Room Proxy)

--- a/docs/stories/backend/US-BE-003-websocket-relay.md
+++ b/docs/stories/backend/US-BE-003-websocket-relay.md
@@ -22,5 +22,13 @@
 - Daemon WebSocket URL is derived from `config.room_ws_url` (e.g. `ws://127.0.0.1:4200/ws/<room_id>`)
 - No message transformation in Phase 1; raw relay only
 
+## Clarifications (Sprint 19 Review)
+
+- **Connection timeout**: 5 second timeout for the initial WebSocket handshake with the room daemon. If the daemon does not complete the upgrade within 5s, return `502 Bad Gateway` to the frontend.
+- **Retry strategy**: On daemon disconnect during an active relay session, reconnect using exponential backoff: 1s, 2s, 4s, 8s, capped at 30s. During reconnection attempts, buffer frontend-bound messages (see backpressure). If the daemon remains unreachable after the max backoff interval, close the frontend connection with a `1011 Internal Error` close code.
+- **Backpressure**: Maintain a 1000-message buffer per client for daemon-to-frontend delivery. On overflow, drop the oldest messages and emit a warning-level log entry including the room ID and number of dropped messages. Do not disconnect the client on overflow.
+- **Keepalive**: Send WebSocket ping frames to the daemon every 30 seconds. If 3 consecutive pongs are missed (90s total), consider the daemon connection dead — close it and initiate the retry strategy above.
+- **Message ordering**: Preserve message order within a single room relay session. No ordering guarantee is made across different room connections (i.e., if a client is relayed to multiple rooms via separate WebSocket connections).
+
 ## Phase
 Phase 1 (Skeleton + Room Proxy)

--- a/docs/stories/backend/US-BE-012-agent-spawn.md
+++ b/docs/stories/backend/US-BE-012-agent-spawn.md
@@ -21,5 +21,16 @@
 - Stdout/stderr of the child process is redirected to `config.data_dir/agents/<agent_id>/agent.log`
 - A background task monitors the child's exit status and updates the SQLite status to `stopped` on exit
 
+## Clarifications (Sprint 19 Review)
+
+- **Spawn failure handling**: Return `500 Internal Server Error` with a JSON body `{"error": "<detail>"}` in the following cases:
+  - `room-ralph` binary not found at `config.ralph_binary_path` or on `PATH`
+  - Agent working directory creation fails (e.g., permission denied, disk full)
+  - Spawned process does not become alive (PID check) within 10 seconds of `Command::spawn()`
+  In all cases, clean up any partially-created resources (directory, SQLite record) before returning.
+- **Duplicate check**: Reject with `409 Conflict` if an agent with the same **username** (not personality) is already running in the same room. Multiple agents with the same personality but different usernames are allowed in the same room (e.g., two `coder` agents). The existing AC for personality-based conflict detection (same personality in same room) is superseded by this username-based check.
+- **Process monitoring**: A background task checks each agent's PID every 30 seconds using a kill-zero probe (`kill(pid, 0)`). If the process is dead, update the SQLite status to `"exited"` and record the exit code if available from the stored `Child` handle. Emit an info-level log entry with the agent ID, room ID, and exit code.
+- **Personality validation**: The `personality` parameter must match the name of an installed personality file. Validate against the set of available personalities at spawn time. Return `400 Bad Request` with `{"error": "unknown personality: <name>"}` if no matching personality is found.
+
 ## Phase
 Phase 2 (Auth + Agent Management)


### PR DESCRIPTION
Adds Clarifications section to 3 backend stories based on sprint 19 review feedback:

- BE-001 (health): daemon timeout (2s), startup behavior, failure recovery (3 strikes), cache invalidation
- BE-003 (WS relay): connection timeout (5s), exponential backoff retry, backpressure (1000 msg buffer), keepalive ping/pong, message ordering guarantees
- BE-012 (agent spawn): spawn failure handling (500 + cleanup), duplicate check on username (not personality), process monitoring (30s), personality validation (400 on unknown)