### PR TITLE
docs: fill story gaps — auth relay, spawn fix, rate limiting

### DIFF
--- a/docs/stories/backend/US-BE-003-websocket-relay.md
+++ b/docs/stories/backend/US-BE-003-websocket-relay.md
@@ -13,6 +13,12 @@
 - [ ] When the frontend disconnects, the daemon connection is torn down cleanly
 - [ ] Connection errors to the daemon return an HTTP `502 Bad Gateway` before the WebSocket upgrade completes
 - [ ] Relay handles at least 100 concurrent connections without degradation
+- [ ] Frontend sends Hive auth token in `Authorization` header or query param; Hive maps it to a room token before connecting to daemon via `SESSION:<room_token>` handshake
+- [ ] If no valid Hive token is provided, the upgrade returns `401 Unauthorized`
+
+## Dependencies
+- US-BE-002 (config — provides `room_ws_url`)
+- US-BE-009 (session management — for auth token validation in Phase 2; Phase 1 can skip auth)
 
 ## Technical Notes
 - Implement in `crates/hive-server/src/ws_relay.rs`

--- a/docs/stories/backend/US-BE-012-agent-spawn.md
+++ b/docs/stories/backend/US-BE-012-agent-spawn.md
@@ -10,8 +10,14 @@
 - [ ] `personality` is a string passed as `--personality` to `room-ralph`; invalid personalities return `400 Bad Request`
 - [ ] `model` defaults to `sonnet` if absent
 - [ ] Agent record is created in SQLite with status `starting`; status transitions to `running` once the process is confirmed alive
-- [ ] Returns `409 Conflict` if an agent with the same `personality` is already running in the same room
+- [ ] Returns `409 Conflict` if an agent with the same `username` is already running in the same room (multiple agents with the same personality are allowed — e.g. coder-anna and coder-kai are both "coder")
 - [ ] Maximum concurrent agents per workspace is enforced (`max_agents_per_workspace` in config, default 10)
+- [ ] Agent username is auto-generated from `<personality>-<name>` where name is picked from the personality's name pool
+- [ ] Spawn failure (process exits within 5s) transitions status to `failed` with error message
+
+## Dependencies
+- US-BE-011 (token mapping — agents need room tokens)
+- US-BE-016 (workspace provisioning — agents need workdirs)
 
 ## Technical Notes
 - Implement in `crates/hive-server/src/agents.rs`

--- a/docs/stories/backend/US-BE-027-rate-limiting.md
+++ b/docs/stories/backend/US-BE-027-rate-limiting.md
@@ -1,0 +1,27 @@
+# US-BE-027: API rate limiting
+
+**As a** platform operator
+**I want to** rate-limit API requests per user
+**So that** no single user can overwhelm the server or spawn excessive agents
+
+## Acceptance Criteria
+- [ ] All authenticated endpoints enforce per-user rate limits
+- [ ] Agent spawn (POST /api/agents) limited to 5 requests per minute per user
+- [ ] Message send (POST /api/rooms/:id/send) limited to 60 requests per minute per user
+- [ ] Other endpoints limited to 120 requests per minute per user
+- [ ] Rate-limited requests return 429 Too Many Requests with Retry-After header
+- [ ] Rate limit state is in-memory (no external store needed for single-host)
+- [ ] Unauthenticated endpoints (/health, /login) exempt from per-user limits but have global IP-based limits
+
+## Dependencies
+- US-BE-009 (session management — need user identity for per-user limits)
+
+## Technical Notes
+- Use tower::limit::RateLimit or a custom middleware with governor crate
+- Store rate limit buckets in DashMap<UserId, RateLimiter> on AppState
+- Agent spawn has the strictest limit because each spawn creates a process
+- Consider burst allowance (token bucket with 5 burst, 1/12s refill for spawn)
+- Log rate-limited requests at WARN level
+
+## Phase
+Phase 2 (Auth + Agent Management)

--- a/docs/stories/backend/US-BE-028-audit-logging.md
+++ b/docs/stories/backend/US-BE-028-audit-logging.md
@@ -1,0 +1,30 @@
+# US-BE-028: Audit Logging
+
+## User Story
+As a platform administrator, I want an immutable audit trail of security-relevant user actions, so that I can investigate incidents, enforce compliance, and understand system usage patterns.
+
+## Acceptance Criteria
+1. The following actions are recorded in the audit log: agent spawn, agent stop, room join, room leave, workspace create, workspace update, workspace delete, API key creation, API key revocation, and login/logout events.
+2. Each audit log entry contains: timestamp (UTC, millisecond precision), actor (user ID or system), action type (enum), target resource (workspace ID, room ID, agent ID as applicable), outcome (success or failure with error code), and source IP address.
+3. Audit records are persisted to a dedicated `audit_log` table in the SQLite database, append-only by application convention (no UPDATE or DELETE queries issued by the application).
+4. An admin endpoint `GET /api/admin/audit` supports filtering by actor, action type, target resource, and time range, with pagination (cursor-based).
+5. Audit log writes never block the primary request path; entries are batched and flushed asynchronously with a maximum flush interval of 2 seconds.
+6. Log entries survive application restarts (no in-memory-only buffer that could be lost on crash).
+7. A retention policy is configurable in `hive.toml` (`audit_retention_days`, default 90); a background task prunes expired entries daily.
+8. Integration tests verify that each auditable action produces exactly one audit record with the correct fields.
+
+## Technical Notes
+- Use a bounded async channel (e.g., `tokio::sync::mpsc` with capacity 4096) to decouple request handling from audit writes. A dedicated flush task drains the channel in batches of up to 256 entries per transaction.
+- Schema: `CREATE TABLE audit_log (id INTEGER PRIMARY KEY, ts TEXT NOT NULL, actor TEXT NOT NULL, action TEXT NOT NULL, target TEXT, outcome TEXT NOT NULL, ip TEXT, detail TEXT)`. The `detail` column holds optional JSON for action-specific metadata.
+- Index on `(ts)` and `(actor, ts)` for efficient range queries.
+- Do not log request/response bodies — only the action and its outcome. Sensitive fields (passwords, tokens) must never appear in the audit log.
+- The audit writer should be injected as a shared handle (e.g., `Arc<AuditWriter>`) into route handlers, not imported as a global.
+
+## Phase & Priority
+- **Phase:** 2
+- **Priority:** P2
+
+## Dependencies
+- Blocked by: US-BE-023 (SQLite persistence — audit records require the database layer), US-BE-008 (authentication — actor identity must be resolved for attribution)
+- Blocks: none currently identified
+- Related: US-BE-027 (rate limiting — rate limit violations may emit audit entries), US-BE-029 (workspace deletion cascade — deletion events are auditable)

--- a/docs/stories/backend/US-BE-029-workspace-deletion-cascade.md
+++ b/docs/stories/backend/US-BE-029-workspace-deletion-cascade.md
@@ -1,0 +1,30 @@
+# US-BE-029: Workspace Deletion Cascade
+
+## User Story
+As a workspace owner, I want deleting a workspace to cleanly stop all running agents, remove workspace files, and cascade-delete all associated database records, so that no orphaned resources or stale state remain after deletion.
+
+## Acceptance Criteria
+1. When a workspace is deleted via `DELETE /api/workspaces/:id`, all agents currently running in that workspace receive a graceful shutdown signal (SIGTERM) with a 10-second timeout before SIGKILL.
+2. Agent processes that do not exit within the timeout are force-killed, and their PIDs are cleaned up from the process table tracking.
+3. All room broker instances associated with the workspace are shut down and their Unix domain sockets are removed from the filesystem.
+4. The workspace data directory (chat logs, token files, cursor files) is recursively deleted from disk.
+5. Database records cascade: workspace row, associated agent records, room records, task entries, and any workspace-scoped configuration are deleted in a single transaction.
+6. The deletion endpoint returns 202 Accepted immediately and performs cleanup asynchronously; a subsequent `GET /api/workspaces/:id` returns 404 once cleanup completes, or 409 Conflict if cleanup is still in progress.
+7. If any cleanup step fails (e.g., filesystem permission error), the workspace is marked as `deletion_failed` with an error message retrievable via the API, rather than being silently left in a half-deleted state.
+8. Integration tests verify the full cascade: spawn agents, create rooms, populate data, delete workspace, then assert all resources are gone and all processes are stopped.
+
+## Technical Notes
+- Implement as a state machine: `Active -> Deleting -> Deleted` (or `DeletionFailed`). The `Deleting` state prevents new agent spawns or room creation in the workspace.
+- Use `PRAGMA foreign_keys = ON` and `ON DELETE CASCADE` on foreign key constraints where possible, but still perform explicit agent shutdown before issuing the SQL delete (foreign keys handle the DB side; application code handles the OS side).
+- Filesystem cleanup should use `tokio::task::spawn_blocking` with `std::fs::remove_dir_all` — do not use `tokio::fs` (cancellation-unsafe, per project invariants).
+- Consider emitting an audit event (US-BE-028) for each sub-step of the cascade to aid debugging if partial failures occur.
+- The 10-second SIGTERM timeout should be configurable in `hive.toml` (`workspace.shutdown_timeout_secs`).
+
+## Phase & Priority
+- **Phase:** 3
+- **Priority:** P1
+
+## Dependencies
+- Blocked by: US-BE-017 (workspace CRUD — the workspace must exist and have standard lifecycle endpoints), US-BE-012 (agent spawn/stop — agent process management primitives must be in place)
+- Blocks: none currently identified
+- Related: US-BE-028 (audit logging — deletion events should be audited), US-BE-023 (SQLite — cascade relies on the database schema and foreign keys)

--- a/docs/stories/backend/US-BE-030-ws-permission-filtering.md
+++ b/docs/stories/backend/US-BE-030-ws-permission-filtering.md
@@ -1,0 +1,29 @@
+# US-BE-030: WebSocket Permission Filtering
+
+## User Story
+As a user connected to Hive via WebSocket, I want the relay to enforce message visibility rules (DM privacy, subscription tiers, and private room access), so that I only receive messages I am authorized to see.
+
+## Acceptance Criteria
+1. Direct messages are delivered only to the sender, the recipient, and workspace hosts; no other WebSocket client receives DM frames.
+2. Subscription tiers (Full, MentionsOnly, Unsubscribed) are enforced on the relay: clients subscribed as MentionsOnly receive only messages that @mention them; Unsubscribed clients receive no messages from that room unless they explicitly poll with a narrowing filter.
+3. Private rooms (when room visibility is implemented) are invisible to non-members: connection attempts to a private room WebSocket endpoint return a 403 Forbidden upgrade rejection, and messages from private rooms are never relayed to non-member connections.
+4. Permission checks are evaluated per-frame before relay, not as a post-filter on the client side; unauthorized frames are silently dropped at the server (no error frame sent to the intended recipient to avoid information leakage).
+5. When a user's subscription tier changes mid-session (e.g., upgraded from MentionsOnly to Full), the relay applies the new tier immediately without requiring reconnection.
+6. Token validation occurs on every WebSocket frame relay cycle; if a token is revoked (via /kick or /reauth), the connection is terminated with a 4001 close code and a JSON reason frame within 5 seconds.
+7. Integration tests cover: DM isolation (third-party client must not see DMs), MentionsOnly filtering (non-mentioned messages dropped), private room rejection, mid-session tier change, and revoked-token disconnection.
+
+## Technical Notes
+- The relay filter should be a function `fn is_visible_to(msg: &Message, client: &ClientState) -> bool` consistent with the existing `is_visible_to` implementation in the room broker. Reuse or delegate to the same logic to avoid divergence.
+- Store each WebSocket client's subscription tiers and room memberships in the relay's connection state (`ClientState`). Update this state on subscription change events without tearing down the socket.
+- For token revocation, maintain a `revoked_tokens: HashSet<Uuid>` that is checked on each relay cycle. Alternatively, use a broadcast channel to notify all relay tasks of revocation events.
+- Frame drop (silent) vs. error frame (noisy): silent drop is the correct default for authorization failures. Only send error frames for client-side errors (malformed JSON, unknown room ID).
+- Performance consideration: permission checks must be O(1) per frame. Avoid database queries in the hot path; cache permissions in memory and invalidate on change events.
+
+## Phase & Priority
+- **Phase:** 2
+- **Priority:** P1
+
+## Dependencies
+- Blocked by: US-BE-003 (WebSocket relay — the relay infrastructure must exist before filtering can be layered on), US-BE-011 (token mapping — token-to-user resolution is required for permission lookups)
+- Blocks: none currently identified
+- Related: US-BE-008 (authentication — token validation is a prerequisite for permission enforcement), US-BE-027 (rate limiting — both operate as per-frame middleware in the relay pipeline)

--- a/docs/stories/backend/US-BE-031-global-search.md
+++ b/docs/stories/backend/US-BE-031-global-search.md
@@ -1,0 +1,31 @@
+# US-BE-031: Global Search
+
+## User Story
+As a user, I want to search across messages and tasks in all workspaces I have access to, so that I can quickly find conversations, decisions, and task references without manually checking each room.
+
+## Acceptance Criteria
+1. A `GET /api/search` endpoint accepts a query string parameter `q` and returns matching messages and tasks ranked by relevance.
+2. Search results are scoped to workspaces and rooms the authenticated user has access to; results from private rooms or workspaces the user is not a member of are excluded.
+3. The endpoint supports filtering by: resource type (`messages`, `tasks`, or both), workspace ID, room ID, author, and date range (`from` / `to` as ISO 8601 timestamps).
+4. Results are paginated with cursor-based pagination; each page returns up to 50 results by default (configurable via `limit` parameter, max 200).
+5. Search matches on message content and task descriptions using SQLite FTS5 full-text search; partial word matching (prefix search) is supported via the `*` suffix operator.
+6. Each result includes: resource type, resource ID, matched snippet (with highlighted match boundaries using `<mark>` tags), room ID, workspace ID, author, and timestamp.
+7. Search indexing does not block message ingestion; new messages and tasks are indexed asynchronously with a maximum lag of 5 seconds under normal load.
+8. Integration tests verify: access-scoped results (user A does not see user B's private room messages), FTS ranking, pagination cursor correctness, filter combinations, and prefix matching.
+
+## Technical Notes
+- Use SQLite FTS5 virtual tables for full-text indexing. Create `messages_fts` and `tasks_fts` tables that mirror the content columns of the underlying tables. Triggers or an async indexer keep them in sync.
+- FTS5 snippet function (`snippet(messages_fts, 0, '<mark>', '</mark>', '...', 32)`) provides match highlighting natively.
+- Ranking: use FTS5's built-in `bm25()` ranking function. Weight message content higher than task descriptions if both are returned in a combined query.
+- Access control: join the FTS results against the user's workspace/room membership tables in the query itself (single SQL query, not post-filter) to avoid leaking result counts.
+- Index maintenance: use `INSERT INTO messages_fts(messages_fts) VALUES('rebuild')` as a maintenance command, exposed via an admin endpoint for manual re-indexing.
+- Consider a configurable `search.max_indexing_lag_secs` in `hive.toml` (default 5) that controls how frequently the async indexer flushes.
+
+## Phase & Priority
+- **Phase:** 3
+- **Priority:** P2
+
+## Dependencies
+- Blocked by: US-BE-023 (SQLite persistence — FTS5 virtual tables require the database layer), US-BE-017 (workspaces — workspace membership is needed for access-scoped results)
+- Blocks: none currently identified
+- Related: US-BE-008 (authentication — caller identity determines result visibility), US-BE-030 (WS permission filtering — shares the concept of per-user visibility scoping)

--- a/docs/stories/frontend/fe-023-settings-panel.md
+++ b/docs/stories/frontend/fe-023-settings-panel.md
@@ -1,0 +1,31 @@
+# FE-023: Settings Panel
+
+## User Story
+As a user, I want a settings view where I can configure my theme preference, notification behavior, API keys, and workspace defaults, so that I can customize Hive to match my workflow without editing configuration files.
+
+## Acceptance Criteria
+1. A Settings view is accessible from the main navigation sidebar and from a user avatar dropdown menu; it opens as a full-page route (`/settings`), not a modal.
+2. The Theme section offers Light, Dark, and System (auto-detect) options; selecting an option applies the theme immediately without a page reload and persists the preference to the backend.
+3. The Notifications section allows toggling: desktop notifications (browser Notification API), sound alerts, and per-workspace mute overrides; changes take effect immediately.
+4. The API Keys section displays existing keys (masked, showing only the last 4 characters), their creation date, and last-used date; users can create new keys (with an optional label) and revoke existing keys with a confirmation dialog.
+5. The Workspace Defaults section lets the user set a default workspace (auto-selected on login) and default subscription tier for new room joins (Full or MentionsOnly).
+6. All settings changes are saved to the backend via `PUT /api/user/settings` and optimistically applied to the UI; if the save fails, the UI reverts the change and displays an error toast.
+7. The Settings view is fully keyboard-navigable; each section is a landmark region with a heading, and all form controls have associated labels.
+8. Unit tests cover each settings section component in isolation; an integration test verifies the round-trip: change setting, reload page, confirm setting persists.
+
+## Technical Notes
+- Use a tabbed or sectioned layout within the Settings page (Theme, Notifications, API Keys, Workspace Defaults). Avoid a single long scrollable form.
+- Theme state should live in a React context (or equivalent framework state) that wraps the entire app, so all components react to theme changes without prop drilling.
+- API key creation should return the full key exactly once (in the creation response). Display it in a copy-to-clipboard field with a warning that it will not be shown again.
+- For desktop notifications, request `Notification.permission` on toggle-on; if the user has previously denied permission, show a help message explaining how to re-enable it in browser settings.
+- Dark mode implementation should use CSS custom properties (variables) on `:root` / `[data-theme="dark"]` rather than conditional class lists on individual components, to keep theme switching performant and maintainable.
+- Consider debouncing settings saves (300ms) for rapid toggles to avoid excessive API calls.
+
+## Phase & Priority
+- **Phase:** 2
+- **Priority:** P2
+
+## Dependencies
+- Blocked by: FE-002 (login/auth — user must be authenticated to load and save settings), FE-022 (dark mode foundation — theme infrastructure must exist before the settings panel can toggle it)
+- Blocks: none currently identified
+- Related: US-BE-008 (backend auth — settings endpoint requires authentication), US-BE-027 (rate limiting — API key management ties into rate limit identity)


### PR DESCRIPTION
Fills gaps from wall-e's review: BE-003 auth token relay, BE-012 username duplicate fix, new BE-027 rate limiting story.