### PR TITLE
feat: Docker setup for Hive (server + web + room daemon)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+target/
+node_modules/
+dist/
+.git/
+*.md
+docs/

--- a/crates/hive-server/Dockerfile
+++ b/crates/hive-server/Dockerfile
@@ -1,0 +1,29 @@
+# Multi-stage Rust build for hive-server
+# Uses cargo-chef for dependency caching
+
+FROM rust:1.84-slim AS chef
+RUN cargo install cargo-chef
+WORKDIR /app
+
+FROM chef AS planner
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ crates/
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
+COPY --from=planner /app/recipe.json recipe.json
+# Build dependencies (cached unless Cargo.toml/lock changes)
+RUN cargo chef cook --release --recipe-path recipe.json
+# Build application
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ crates/
+RUN cargo build --release --bin hive
+
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=builder /app/target/release/hive /usr/local/bin/hive
+EXPOSE 3000
+ENV RUST_LOG=hive=info
+CMD ["hive"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+version: "3.9"
+
+services:
+  # Room daemon — real-time messaging infrastructure
+  room-daemon:
+    image: rust:1.84-slim
+    command: >
+      sh -c "
+        cargo install room-cli --version 3.5.1 &&
+        room daemon --ws-port 4200
+      "
+    volumes:
+      - room-data:/root/.room
+    expose:
+      - "4200"
+    networks:
+      - hive-net
+
+  # Hive backend — axum server proxying to room daemon
+  hive-server:
+    build:
+      context: .
+      dockerfile: crates/hive-server/Dockerfile
+    environment:
+      RUST_LOG: hive=info
+    volumes:
+      - hive-data:/app/data
+      - ./hive.toml:/app/hive.toml:ro
+    ports:
+      - "3000:3000"
+    depends_on:
+      - room-daemon
+    networks:
+      - hive-net
+
+  # Hive frontend — React web dashboard
+  hive-web:
+    build:
+      context: hive-web
+      dockerfile: Dockerfile
+    ports:
+      - "8080:80"
+    depends_on:
+      - hive-server
+    networks:
+      - hive-net
+
+volumes:
+  room-data:
+  hive-data:
+
+networks:
+  hive-net:
+    driver: bridge

--- a/hive-web/Dockerfile
+++ b/hive-web/Dockerfile
@@ -1,0 +1,22 @@
+# Multi-stage build for hive-web frontend
+# Uses pnpm for package management
+
+FROM node:22-slim AS base
+RUN corepack enable && corepack prepare pnpm@latest --activate
+WORKDIR /app
+
+FROM base AS deps
+COPY package.json pnpm-lock.yaml* ./
+RUN pnpm install --frozen-lockfile 2>/dev/null || pnpm install
+
+FROM base AS builder
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN pnpm build
+
+# Serve with a lightweight static server
+FROM nginx:alpine AS runtime
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/hive-web/nginx.conf
+++ b/hive-web/nginx.conf
@@ -1,0 +1,26 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA fallback — all routes serve index.html
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Proxy API and WebSocket to hive-server
+    location /api/ {
+        proxy_pass http://hive-server:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location /ws/ {
+        proxy_pass http://hive-server:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_read_timeout 86400;
+    }
+}

--- a/hive.toml
+++ b/hive.toml
@@ -1,0 +1,11 @@
+# Hive server configuration
+# Used by docker-compose — adjust for local development
+
+[server]
+host = "0.0.0.0"
+port = 3000
+data_dir = "/app/data"
+
+[daemon]
+socket_path = "/tmp/roomd.sock"
+ws_url = "ws://room-daemon:4200"


### PR DESCRIPTION
Docker containerization for the full Hive stack:

- **hive-server Dockerfile**: multi-stage Rust build with cargo-chef dependency caching
- **hive-web Dockerfile**: pnpm + vite build, served via nginx with SPA fallback
- **nginx.conf**: proxies /api/ and /ws/ to hive-server
- **docker-compose.yml**: 3 services — room-daemon (messaging), hive-server (backend), hive-web (frontend)
- **hive.toml**: default config pointing to room-daemon container
- **.dockerignore**: excludes build artifacts

Usage: `docker compose up --build`
- Frontend: http://localhost:8080
- Backend API: http://localhost:3000
- Room daemon: ws://room-daemon:4200 (internal)