### PR TITLE
fix: remove unused SinkExt import

### DIFF
--- a/crates/hive-server/src/daemon.rs
+++ b/crates/hive-server/src/daemon.rs
@@ -6,7 +6,7 @@
 
 use std::time::Duration;
 
-use futures_util::{SinkExt, StreamExt};
+use futures_util::StreamExt;
 use tokio_tungstenite::{connect_async, tungstenite::Message as WsMessage};
 
 /// Configuration for connecting to the room daemon.


### PR DESCRIPTION
Removes unused `SinkExt` import in daemon.rs that caused a compiler warning.