### PR TITLE
fix: default data_dir to ~/.hive/data

### DIFF
--- a/crates/hive-server/Cargo.toml
+++ b/crates/hive-server/Cargo.toml
@@ -21,6 +21,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio-tungstenite = "0.28"
 futures-util = "0.3"
 rusqlite = { version = "0.34", features = ["bundled"] }
+dirs = "6"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/hive-server/src/config.rs
+++ b/crates/hive-server/src/config.rs
@@ -50,10 +50,15 @@ impl Default for HiveConfig {
 
 impl Default for ServerConfig {
     fn default() -> Self {
+        let data_dir = dirs::home_dir()
+            .map(|h| h.join(".hive").join("data"))
+            .unwrap_or_else(|| PathBuf::from("data"))
+            .to_string_lossy()
+            .into_owned();
         Self {
             host: "127.0.0.1".to_owned(),
             port: 3000,
-            data_dir: "data".to_owned(),
+            data_dir,
         }
     }
 }


### PR DESCRIPTION
Fixes crash on read-only filesystem when using default config. Changes default data_dir from relative 'data' to ~/.hive/data.