### PR TITLE
fix: default data_dir to ~/.hive/data, graceful error on read-only fs

### DIFF
--- a/crates/hive-server/src/config.rs
+++ b/crates/hive-server/src/config.rs
@@ -50,10 +50,14 @@ impl Default for HiveConfig {
 
 impl Default for ServerConfig {
     fn default() -> Self {
+        let data_dir = std::env::var("HIVE_DATA_DIR").unwrap_or_else(|_| {
+            let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_owned());
+            format!("{home}/.hive/data")
+        });
         Self {
             host: "127.0.0.1".to_owned(),
             port: 3000,
-            data_dir: "data".to_owned(),
+            data_dir,
         }
     }
 }

--- a/crates/hive-server/src/main.rs
+++ b/crates/hive-server/src/main.rs
@@ -55,7 +55,14 @@ async fn main() {
     // Database
     let db_path = PathBuf::from(&config.server.data_dir).join("hive.db");
     if let Some(parent) = db_path.parent() {
-        std::fs::create_dir_all(parent).expect("failed to create data directory");
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            eprintln!(
+                "[hive] error: cannot create data directory {}: {e}\n\
+                 hint: set data_dir in hive.toml or HIVE_DATA_DIR env to a writable path",
+                parent.display()
+            );
+            std::process::exit(1);
+        }
     }
     let db = db::Database::open(&db_path).expect("failed to open database");
     tracing::info!("database opened at {}", db_path.display());


### PR DESCRIPTION
Fixes panic on startup when running on read-only filesystem. Default data_dir changed from 'data' (relative) to ~/.hive/data. Respects HIVE_DATA_DIR env var. Replaces panic with helpful error message pointing to config.