### PR TITLE
fix: bump Docker Rust to 1.87, remove obsolete version field

### DIFF
--- a/crates/hive-server/Dockerfile
+++ b/crates/hive-server/Dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage Rust build for hive-server
 # Uses cargo-chef for dependency caching
 
-FROM rust:1.84-slim AS chef
+FROM rust:1.87-slim AS chef
 RUN cargo install cargo-chef
 WORKDIR /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,7 @@
-version: "3.9"
-
 services:
   # Room daemon — real-time messaging infrastructure
   room-daemon:
-    image: rust:1.84-slim
+    image: rust:1.87-slim
     command: >
       sh -c "
         cargo install room-cli --version 3.5.1 &&
@@ -25,7 +23,7 @@ services:
       RUST_LOG: hive=info
     volumes:
       - hive-data:/app/data
-      - ./hive.toml:/app/hive.toml:ro
+      - ./hive.toml.example:/app/hive.toml:ro
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
- Dockerfile: rust:1.84-slim -> rust:1.87-slim (cargo-chef needs 1.85+)
- docker-compose.yml: remove obsolete version: field, bump room-daemon image, fix hive.toml reference