### PR TITLE
fix: use rust:1-slim instead of pinned 1.87 in Docker

### DIFF
--- a/crates/hive-server/Dockerfile
+++ b/crates/hive-server/Dockerfile
@@ -1,8 +1,8 @@
 # Multi-stage Rust build for hive-server
 # Uses cargo-chef for dependency caching
 
-FROM rust:1.87-slim AS chef
-RUN cargo install cargo-chef
+FROM rust:1-slim AS chef
+RUN cargo install cargo-chef --locked
 WORKDIR /app
 
 FROM chef AS planner

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   # Room daemon — real-time messaging infrastructure
   room-daemon:
-    image: rust:1.87-slim
+    image: rust:1-slim
     command: >
       sh -c "
         cargo install room-cli --version 3.5.1 &&


### PR DESCRIPTION
Tracks latest Rust 1.x automatically instead of pinning a stale version. Also adds --locked to cargo install cargo-chef.

- [ ] Verified docs/README are accurate after this change (no drift)