### PR TITLE
fix(web): fix TypeScript errors in useWebSocket hook

### DIFF
--- a/hive-web/src/hooks/useWebSocket.ts
+++ b/hive-web/src/hooks/useWebSocket.ts
@@ -59,7 +59,7 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
   const [messages, setMessages] = useState<RoomMessage[]>([]);
   const wsRef = useRef<WebSocket | null>(null);
   const retriesRef = useRef(0);
-  const retryTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   const disconnect = useCallback(() => {
     retriesRef.current = maxRetries; // prevent reconnect
@@ -91,7 +91,7 @@ export function useWebSocket(options: UseWebSocketOptions): UseWebSocketReturn {
       try {
         const data = JSON.parse(event.data) as RoomMessage;
         setMessages((prev) => [...prev, data]);
-      } catch {
+      } catch (_) {
         // Non-JSON message — ignore
       }
     };


### PR DESCRIPTION
Fixes useRef() call that needs an initial value argument in strict mode, and catch without binding. Apologies for not running tsc before pushing.