### PR TITLE
fix: install pnpm directly in Docker (node:22-slim lacks corepack)

### DIFF
--- a/hive-web/Dockerfile
+++ b/hive-web/Dockerfile
@@ -2,7 +2,7 @@
 # Uses pnpm for package management
 
 FROM node:22-slim AS base
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN npm install -g pnpm
 WORKDIR /app
 
 FROM base AS deps


### PR DESCRIPTION
node:22-slim doesn't include corepack. Switch to npm install -g pnpm.