### PR TITLE
fix: switch to node:22 full image — slim lacks npm

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,12 +24,11 @@ services:
 
   # Hive frontend — dev mode with Vite HMR
   hive-web:
-    image: node:22-slim
+    image: node:22
     working_dir: /app
     command: >
       sh -c "
-        corepack enable &&
-        corepack prepare pnpm@latest --activate &&
+        npm install -g pnpm &&
         pnpm install &&
         pnpm dev --host 0.0.0.0 --port 5173
       "

--- a/hive-web/Dockerfile
+++ b/hive-web/Dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage build for hive-web frontend
 # Uses pnpm for package management
 
-FROM node:22-slim AS base
+FROM node:22 AS base
 RUN npm install -g pnpm
 WORKDIR /app
 


### PR DESCRIPTION
node:22-slim strips npm, npx, and corepack. Switch to node:22 in Dockerfile and docker-compose.dev.yml.