### PR TITLE
fix: Docker dev uses full registry ref + --pull to prevent image name collision

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,7 +24,7 @@ services:
 
   # Hive frontend — dev mode with Vite HMR
   hive-web:
-    image: node:22
+    image: docker.io/library/node:22
     working_dir: /app
     command: >
       sh -c "

--- a/justfile
+++ b/justfile
@@ -2,15 +2,15 @@
 # Install: cargo install just
 # Prerequisites: rust, node 22+, just, docker (for `just dev`)
 
-# Ensure pnpm is available via corepack
+# Ensure pnpm is available
 setup:
-    corepack enable
+    npm install -g pnpm
     cd hive-web && pnpm install
 
 # Start all services for development (room daemon + hive-server + hive-web)
 dev:
     @echo "Starting Hive dev environment..."
-    docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+    docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build --pull always
 
 # Start services without Docker (requires room, cargo, node on PATH)
 dev-local:


### PR DESCRIPTION
node:22 image got overwritten by build output. Use docker.io/library/node:22 explicit ref, add --pull always to just dev, fix setup to use npm instead of corepack.