### PR TITLE
fix: install pnpm via standalone script — no npm dependency

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,11 +24,13 @@ services:
 
   # Hive frontend — dev mode with Vite HMR
   hive-web:
-    image: docker.io/library/node:22
+    image: docker.io/library/node:22-bookworm-slim
     working_dir: /app
     command: >
       sh -c "
-        npm install -g pnpm &&
+        apt-get update && apt-get install -y curl > /dev/null 2>&1 &&
+        curl -fsSL https://get.pnpm.io/install.sh | SHELL=/bin/bash bash - &&
+        export PATH=\"/root/.local/share/pnpm:$$PATH\" &&
         pnpm install &&
         pnpm dev --host 0.0.0.0 --port 5173
       "

--- a/hive-web/Dockerfile
+++ b/hive-web/Dockerfile
@@ -1,8 +1,10 @@
 # Multi-stage build for hive-web frontend
 # Uses pnpm for package management
 
-FROM node:22 AS base
-RUN npm install -g pnpm
+FROM node:22-bookworm-slim AS base
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL https://get.pnpm.io/install.sh | SHELL=/bin/bash bash - \
+    && ln -s /root/.local/share/pnpm/pnpm /usr/local/bin/pnpm
 WORKDIR /app
 
 FROM base AS deps


### PR DESCRIPTION
Replaces npm install -g pnpm with curl-based standalone installer. Uses node:22-bookworm-slim (has apt-get for curl). Zero dependency on npm existing in the Docker image. Fixes the npm: not found error on Apple Silicon.