### PR TITLE
fix: use ENV PATH for pnpm instead of symlink

### DIFF
--- a/hive-web/Dockerfile
+++ b/hive-web/Dockerfile
@@ -2,9 +2,10 @@
 # Uses pnpm for package management
 
 FROM node:22-bookworm-slim AS base
+ENV PNPM_HOME="/root/.local/share/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL https://get.pnpm.io/install.sh | SHELL=/bin/bash bash - \
-    && ln -s /root/.local/share/pnpm/pnpm /usr/local/bin/pnpm
+    && curl -fsSL https://get.pnpm.io/install.sh | ENV="$HOME/.bashrc" SHELL=/bin/bash bash -
 WORKDIR /app
 
 FROM base AS deps


### PR DESCRIPTION
The standalone pnpm installer creates a wrapper script. Symlink approach fails. Use PNPM_HOME + PATH env vars instead.