### PR TITLE
fix: use node:lts + npm — eliminates curl/apt-get entirely

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,13 +24,11 @@ services:
 
   # Hive frontend — dev mode with Vite HMR
   hive-web:
-    image: docker.io/library/node:22-bookworm-slim
+    image: docker.io/library/node:lts
     working_dir: /app
     command: >
       sh -c "
-        apt-get update && apt-get install -y curl > /dev/null 2>&1 &&
-        curl -fsSL https://get.pnpm.io/install.sh | SHELL=/bin/bash bash - &&
-        export PATH=\"/root/.local/share/pnpm:$$PATH\" &&
+        npm install -g pnpm &&
         pnpm install &&
         pnpm dev --host 0.0.0.0 --port 5173
       "

--- a/hive-web/Dockerfile
+++ b/hive-web/Dockerfile
@@ -1,11 +1,8 @@
 # Multi-stage build for hive-web frontend
 # Uses pnpm for package management
 
-FROM node:22-bookworm-slim AS base
-ENV PNPM_HOME="/root/.local/share/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL https://get.pnpm.io/install.sh | ENV="$HOME/.bashrc" SHELL=/bin/bash bash -
+FROM node:lts AS base
+RUN npm install -g pnpm
 WORKDIR /app
 
 FROM base AS deps


### PR DESCRIPTION
Replaces the curl+apt-get approach with node:lts (confirmed by joao to have npm) + npm install -g pnpm. No apt-get, no curl, no standalone installer, no PATH issues.