### PR TITLE
fix: docker-compose.dev.yml node:lts + npm (matches Dockerfile)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,10 +24,13 @@ services:
 
   # Hive frontend — dev mode with Vite HMR
   hive-web:
-    image: docker.io/library/node:lts
+    image: debian:bookworm-slim
     working_dir: /app
     command: >
       sh -c "
+        apt-get update && apt-get install -y curl ca-certificates gnupg &&
+        curl -fsSL https://deb.nodesource.com/setup_22.x | bash - &&
+        apt-get install -y nodejs &&
         npm install -g pnpm &&
         pnpm install &&
         pnpm dev --host 0.0.0.0 --port 5173

--- a/hive-web/Dockerfile
+++ b/hive-web/Dockerfile
@@ -1,8 +1,13 @@
 # Multi-stage build for hive-web frontend
 # Uses pnpm for package management
 
-FROM node:lts AS base
-RUN npm install -g pnpm
+FROM debian:bookworm-slim AS base
+RUN apt-get update \
+    && apt-get install -y curl ca-certificates gnupg \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
+    && npm install -g pnpm \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
 FROM base AS deps


### PR DESCRIPTION
The dev compose was still using node:22-bookworm-slim with apt-get/curl. Switches to node:lts + npm install -g pnpm to match the Dockerfile fix from PR #39.