### PR TITLE
fix: use debian:bookworm-slim + nodesource — ARM Docker compatible

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,11 +24,13 @@ services:
 
   # Hive frontend — dev mode with Vite HMR
   hive-web:
-    image: docker.io/library/node:lts
+    build:
+      context: ./hive-web
+      dockerfile: Dockerfile
+      target: base
     working_dir: /app
     command: >
       sh -c "
-        npm install -g pnpm &&
         pnpm install &&
         pnpm dev --host 0.0.0.0 --port 5173
       "

--- a/hive-web/Dockerfile
+++ b/hive-web/Dockerfile
@@ -1,8 +1,13 @@
 # Multi-stage build for hive-web frontend
 # Uses pnpm for package management
 
-FROM node:lts AS base
-RUN npm install -g pnpm
+FROM debian:bookworm-slim AS base
+RUN apt-get update \
+    && apt-get install -y curl \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
+    && npm install -g pnpm \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
 FROM base AS deps


### PR DESCRIPTION
Replaces broken node: images with debian:bookworm-slim + nodesource Node 22 install. Guarantees npm exists on all platforms including ARM Docker Desktop. Dev compose now builds from Dockerfile base stage instead of pulling a raw image.