### PR TITLE
fix: dev compose builds from Dockerfile base stage (has node+pnpm)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,15 +23,15 @@ services:
       HIVE_DATA_DIR: /root/.hive/data
 
   # Hive frontend — dev mode with Vite HMR
+  # Builds from Dockerfile base stage (has node+npm+pnpm pre-installed)
   hive-web:
-    image: debian:bookworm-slim
+    build:
+      context: ./hive-web
+      dockerfile: Dockerfile
+      target: base
     working_dir: /app
     command: >
       sh -c "
-        apt-get update && apt-get install -y curl ca-certificates gnupg &&
-        curl -fsSL https://deb.nodesource.com/setup_22.x | bash - &&
-        apt-get install -y nodejs &&
-        npm install -g pnpm &&
         pnpm install &&
         pnpm dev --host 0.0.0.0 --port 5173
       "


### PR DESCRIPTION
The image: override in docker-compose.dev.yml kept getting overwritten by Docker build output naming collisions. Fix: use build: with target: base from the Dockerfile, which has node+npm+pnpm pre-installed. Command only runs pnpm install + pnpm dev.