### PR TITLE
fix: explicit image names in docker-compose prevent base image overwrite

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,6 +25,7 @@ services:
   # Hive frontend — dev mode with Vite HMR
   # Builds from Dockerfile base stage (has node+npm+pnpm pre-installed)
   hive-web:
+    image: hive-web:dev
     build:
       context: ./hive-web
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
 
   # Hive backend — axum server proxying to room daemon
   hive-server:
+    image: hive-server:latest
     build:
       context: .
       dockerfile: crates/hive-server/Dockerfile
@@ -33,6 +34,7 @@ services:
 
   # Hive frontend — React web dashboard
   hive-web:
+    image: hive-web:latest
     build:
       context: hive-web
       dockerfile: Dockerfile


### PR DESCRIPTION
Root cause of all Docker failures: Docker exports build output using the base image tag name, overwriting node:22/debian:bookworm-slim locally. Fix: add explicit image: names (hive-server:latest, hive-web:latest, hive-web:dev) so builds don't corrupt base image cache.