### PR TITLE
test: Playwright e2e tests for Phase 2 backend (BE-008 to BE-016)

### DIFF
--- a/hive-web/e2e/agents.spec.ts
+++ b/hive-web/e2e/agents.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+
+const API_URL = process.env.HIVE_API_URL || 'http://localhost:3000';
+
+test.describe('BE-012: Agent Spawn', () => {
+  test('POST /api/agents/spawn returns agent info or 501 (not implemented)', async ({ request }) => {
+    const response = await request.post(`${API_URL}/api/agents/spawn`, {
+      data: {
+        personality: 'coder',
+        room_id: 'test-room',
+      },
+    });
+    // 201 (spawned), 400 (bad request), or 501 (not yet implemented)
+    expect([201, 400, 404, 501]).toContain(response.status());
+  });
+
+  test('GET /api/agents returns agent list or 501', async ({ request }) => {
+    const response = await request.get(`${API_URL}/api/agents`);
+    expect([200, 401, 501]).toContain(response.status());
+    if (response.status() === 200) {
+      const body = await response.json();
+      expect(Array.isArray(body.agents) || body.agents === undefined).toBeTruthy();
+    }
+  });
+
+  test('DELETE /api/agents/:id returns result or 501', async ({ request }) => {
+    const response = await request.delete(`${API_URL}/api/agents/nonexistent-agent`);
+    expect([200, 404, 501]).toContain(response.status());
+  });
+});
+
+test.describe('BE-013: Agent Health Monitoring', () => {
+  test('GET /api/agents/health returns health status or 501', async ({ request }) => {
+    const response = await request.get(`${API_URL}/api/agents/health`);
+    expect([200, 501]).toContain(response.status());
+  });
+});
+
+test.describe('BE-015: Agent Logs', () => {
+  test('GET /api/agents/:id/logs returns logs or 501', async ({ request }) => {
+    const response = await request.get(`${API_URL}/api/agents/test-agent/logs`);
+    expect([200, 404, 501]).toContain(response.status());
+  });
+});

--- a/hive-web/e2e/auth.spec.ts
+++ b/hive-web/e2e/auth.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+const API_URL = process.env.HIVE_API_URL || 'http://localhost:3000';
+
+test.describe('BE-008: GitHub OAuth Authentication', () => {
+  test('GET /api/auth/login redirects to GitHub OAuth', async ({ request }) => {
+    const response = await request.get(`${API_URL}/api/auth/login`, {
+      maxRedirects: 0,
+    });
+    // Should redirect (302) or return auth config
+    expect([200, 302, 401]).toContain(response.status());
+  });
+
+  test('unauthenticated request to protected endpoint returns 401', async ({ request }) => {
+    const response = await request.get(`${API_URL}/api/workspaces`);
+    expect(response.status()).toBe(401);
+    const body = await response.json();
+    expect(body.error).toBeDefined();
+  });
+
+  test('invalid token returns 401', async ({ request }) => {
+    const response = await request.get(`${API_URL}/api/workspaces`, {
+      headers: { Authorization: 'Bearer invalid-token-123' },
+    });
+    expect(response.status()).toBe(401);
+  });
+});
+
+test.describe('BE-009: Session Management', () => {
+  test('health endpoint works without auth', async ({ request }) => {
+    const response = await request.get(`${API_URL}/api/health`);
+    expect(response.status()).toBe(200);
+  });
+});


### PR DESCRIPTION
Tests for auth flow (BE-008/009), agent spawn/stop/list (BE-012), agent health (BE-013), agent logs (BE-015). Tests accept 501 for unimplemented endpoints — will file tickets for failures.