### PR TITLE
fix: REST proxy auth forwarding + daemon_connected (#60)

### DIFF
--- a/crates/hive-server/src/rest_proxy.rs
+++ b/crates/hive-server/src/rest_proxy.rs
@@ -1,40 +1,75 @@
 //! REST proxy — forwards API requests to the co-located room daemon.
 //!
 //! Implements BE-004 through BE-007: room list, room info, messages, send.
+//! Forwards Authorization headers from the client to the daemon.
 
 use std::sync::Arc;
 
 use axum::{
     extract::{Path, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     Json,
 };
 use serde_json::Value;
 
 use crate::AppState;
 
+/// Extract the daemon REST base URL from config.
+fn daemon_base(state: &AppState) -> String {
+    state
+        .config
+        .daemon
+        .ws_url
+        .replace("ws://", "http://")
+        .replace("wss://", "https://")
+}
+
+/// Build a reqwest client with optional auth header forwarding.
+fn build_request(
+    client: &reqwest::Client,
+    method: reqwest::Method,
+    url: &str,
+    headers: &HeaderMap,
+) -> reqwest::RequestBuilder {
+    let mut req = client.request(method, url);
+    // Forward Authorization header to room daemon
+    if let Some(auth) = headers.get("authorization") {
+        if let Ok(val) = auth.to_str() {
+            req = req.header("Authorization", val);
+        }
+    }
+    req
+}
+
 /// GET /api/rooms — list available rooms from the daemon.
 pub async fn list_rooms(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
 ) -> Result<Json<Value>, StatusCode> {
-    let daemon_url = &state.config.daemon.ws_url;
-    let base = daemon_url.replace("ws://", "http://").replace("wss://", "https://");
-    let url = format!("{base}/api/health");
-
-    // Room daemon doesn't have a "list rooms" REST endpoint by default.
-    // Return discovered rooms from daemon health or a placeholder.
+    let base = daemon_base(&state);
     let client = reqwest::Client::new();
-    match client.get(&url).send().await {
+
+    // Try daemon health endpoint to discover rooms
+    let health_url = format!("{base}/api/health");
+    match build_request(&client, reqwest::Method::GET, &health_url, &headers)
+        .send()
+        .await
+    {
         Ok(resp) => {
             let body: Value = resp.json().await.unwrap_or_default();
-            // Extract room info from health response if available
-            let room = body.get("room").and_then(|r| r.as_str()).unwrap_or("default");
+            let room = body
+                .get("room")
+                .and_then(|r| r.as_str())
+                .unwrap_or("default");
+            let users = body.get("users").and_then(|u| u.as_u64()).unwrap_or(0);
             Ok(Json(serde_json::json!({
-                "rooms": [{ "id": room, "name": room }]
+                "rooms": [{ "id": room, "name": room, "users": users }],
+                "daemon_connected": true
             })))
         }
         Err(_) => Ok(Json(serde_json::json!({
             "rooms": [],
+            "daemon_connected": false,
             "error": "daemon unavailable"
         }))),
     }
@@ -44,24 +79,31 @@ pub async fn list_rooms(
 pub async fn get_room(
     State(state): State<Arc<AppState>>,
     Path(room_id): Path<String>,
+    headers: HeaderMap,
 ) -> Result<Json<Value>, StatusCode> {
-    let daemon_url = &state.config.daemon.ws_url;
-    let base = daemon_url.replace("ws://", "http://").replace("wss://", "https://");
+    let base = daemon_base(&state);
     let url = format!("{base}/api/{room_id}/poll");
 
     let client = reqwest::Client::new();
-    match client.get(&url).send().await {
-        Ok(resp) if resp.status().is_success() => {
-            Ok(Json(serde_json::json!({
-                "id": room_id,
-                "name": room_id,
-                "status": "active"
-            })))
-        }
-        _ => Ok(Json(serde_json::json!({
+    match build_request(&client, reqwest::Method::GET, &url, &headers)
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => Ok(Json(serde_json::json!({
             "id": room_id,
             "name": room_id,
-            "status": "unknown"
+            "status": "active"
+        }))),
+        Ok(resp) => Ok(Json(serde_json::json!({
+            "id": room_id,
+            "name": room_id,
+            "status": "error",
+            "daemon_status": resp.status().as_u16()
+        }))),
+        Err(_) => Ok(Json(serde_json::json!({
+            "id": room_id,
+            "name": room_id,
+            "status": "daemon_unavailable"
         }))),
     }
 }
@@ -70,15 +112,21 @@ pub async fn get_room(
 pub async fn get_messages(
     State(state): State<Arc<AppState>>,
     Path(room_id): Path<String>,
+    headers: HeaderMap,
 ) -> Result<Json<Value>, StatusCode> {
-    let daemon_url = &state.config.daemon.ws_url;
-    let base = daemon_url.replace("ws://", "http://").replace("wss://", "https://");
+    let base = daemon_base(&state);
     let url = format!("{base}/api/{room_id}/poll");
 
     let client = reqwest::Client::new();
-    match client.get(&url).send().await {
+    match build_request(&client, reqwest::Method::GET, &url, &headers)
+        .send()
+        .await
+    {
         Ok(resp) => {
-            let body: Value = resp.json().await.unwrap_or(serde_json::json!({"messages": []}));
+            let body: Value = resp
+                .json()
+                .await
+                .unwrap_or(serde_json::json!({"messages": []}));
             Ok(Json(body))
         }
         Err(e) => Ok(Json(serde_json::json!({
@@ -92,17 +140,26 @@ pub async fn get_messages(
 pub async fn send_message(
     State(state): State<Arc<AppState>>,
     Path(room_id): Path<String>,
+    headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> Result<Json<Value>, StatusCode> {
-    let daemon_url = &state.config.daemon.ws_url;
-    let base = daemon_url.replace("ws://", "http://").replace("wss://", "https://");
+    let base = daemon_base(&state);
     let url = format!("{base}/api/{room_id}/send");
 
     let client = reqwest::Client::new();
-    match client.post(&url).json(&body).send().await {
-        Ok(resp) => {
+    match build_request(&client, reqwest::Method::POST, &url, &headers)
+        .json(&body)
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => {
             let result: Value = resp.json().await.unwrap_or_default();
             Ok(Json(result))
+        }
+        Ok(resp) => {
+            let status = resp.status().as_u16();
+            let _error: Value = resp.json().await.unwrap_or_default();
+            Err(StatusCode::from_u16(status).unwrap_or(StatusCode::BAD_GATEWAY))
         }
         Err(_) => Err(StatusCode::BAD_GATEWAY),
     }


### PR DESCRIPTION
Fixes #60 — REST proxy improvements:
- Forward Authorization header to room daemon on all proxy requests
- Add daemon_connected field to rooms list response
- Add daemon error status codes to room info
- Refactor: shared helpers for daemon URL + request building