### PR TITLE
fix: health daemon_connected + config HIVE_HOST/HIVE_PORT env vars (#59, #65)

### DIFF
--- a/crates/hive-server/src/config.rs
+++ b/crates/hive-server/src/config.rs
@@ -50,13 +50,18 @@ impl Default for HiveConfig {
 
 impl Default for ServerConfig {
     fn default() -> Self {
+        let host = std::env::var("HIVE_HOST").unwrap_or_else(|_| "127.0.0.1".to_owned());
+        let port = std::env::var("HIVE_PORT")
+            .ok()
+            .and_then(|p| p.parse().ok())
+            .unwrap_or(3000);
         let data_dir = std::env::var("HIVE_DATA_DIR").unwrap_or_else(|_| {
             let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_owned());
             format!("{home}/.hive/data")
         });
         Self {
-            host: "127.0.0.1".to_owned(),
-            port: 3000,
+            host,
+            port,
             data_dir,
         }
     }

--- a/crates/hive-server/src/main.rs
+++ b/crates/hive-server/src/main.rs
@@ -25,14 +25,29 @@ struct HealthResponse {
     status: &'static str,
     version: &'static str,
     uptime_secs: u64,
+    daemon_connected: bool,
+    daemon_url: String,
 }
 
-/// GET /api/health — returns server status, version, and uptime.
+/// GET /api/health — returns server status, version, uptime, and daemon connection.
 async fn health(state: axum::extract::State<Arc<AppState>>) -> Json<HealthResponse> {
+    let daemon_url = state.config.daemon.ws_url.clone();
+    let base = daemon_url.replace("ws://", "http://").replace("wss://", "https://");
+    let daemon_connected = reqwest::Client::new()
+        .get(format!("{base}/api/health"))
+        .timeout(std::time::Duration::from_secs(2))
+        .send()
+        .await
+        .is_ok();
+
+    let status = if daemon_connected { "ok" } else { "degraded" };
+
     Json(HealthResponse {
-        status: "ok",
+        status,
         version: env!("CARGO_PKG_VERSION"),
         uptime_secs: state.start_time.elapsed().as_secs(),
+        daemon_connected,
+        daemon_url,
     })
 }
 


### PR DESCRIPTION
Health endpoint now shows daemon_connected, daemon_url, and degraded status when daemon unavailable. Config supports HIVE_HOST and HIVE_PORT env vars. Closes #59, #65.