### PR TITLE
fix: update Playwright test expectations for health endpoint changes

### DIFF
--- a/hive-web/e2e/health.spec.ts
+++ b/hive-web/e2e/health.spec.ts
@@ -3,11 +3,19 @@ import { test, expect } from '@playwright/test';
 const API_URL = process.env.HIVE_API_URL || 'http://localhost:3000';
 
 test.describe('BE-001: Health Endpoint', () => {
-  test('GET /api/health returns 200 with status ok', async ({ request }) => {
+  test('GET /api/health returns 200 with valid status', async ({ request }) => {
     const response = await request.get(`${API_URL}/api/health`);
     expect(response.status()).toBe(200);
     const body = await response.json();
-    expect(body.status).toBe('ok');
+    // 'ok' when daemon connected, 'degraded' when daemon unavailable
+    expect(['ok', 'degraded']).toContain(body.status);
+  });
+
+  test('health response includes daemon_connected field', async ({ request }) => {
+    const response = await request.get(`${API_URL}/api/health`);
+    const body = await response.json();
+    expect(typeof body.daemon_connected).toBe('boolean');
+    expect(body.daemon_url).toBeDefined();
   });
 
   test('health response includes version', async ({ request }) => {

--- a/hive-web/e2e/infrastructure.spec.ts
+++ b/hive-web/e2e/infrastructure.spec.ts
@@ -26,7 +26,7 @@ test.describe('BE-026: Graceful Shutdown', () => {
     const response = await request.get(`${API_URL}/api/health`);
     expect(response.status()).toBe(200);
     const body = await response.json();
-    expect(body.status).toBe('ok');
+    expect(['ok', 'degraded']).toContain(body.status);
   });
 });
 


### PR DESCRIPTION
Health endpoint now returns 'degraded' when daemon unavailable (from #73). Tests updated to accept both 'ok' and 'degraded'. Added daemon_connected field test. Fixes 8 Playwright failures.