### PR TITLE
fix: add openssl deps to Dockerfile chef stage, make Cargo.lock writable in dev (#76)

### DIFF
--- a/crates/hive-server/Dockerfile
+++ b/crates/hive-server/Dockerfile
@@ -2,6 +2,7 @@
 # Uses cargo-chef for dependency caching
 
 FROM rust:1-slim AS chef
+RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
 RUN cargo install cargo-chef --locked
 WORKDIR /app
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -16,7 +16,7 @@ services:
     volumes:
       - ./crates:/app/crates:ro
       - ./Cargo.toml:/app/Cargo.toml:ro
-      - ./Cargo.lock:/app/Cargo.lock:ro
+      - ./Cargo.lock:/app/Cargo.lock
       - hive-data:/root/.hive
     environment:
       RUST_LOG: hive=debug


### PR DESCRIPTION
## Summary
- Add `pkg-config` and `libssl-dev` to the Dockerfile `chef` stage so the dev compose build doesn't fail after `reqwest` (which pulls `openssl-sys`) was added
- Remove `:ro` from `Cargo.lock` volume mount in `docker-compose.dev.yml` so Cargo can update it when dependencies change

## Test plan
- [ ] `docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build` completes successfully
- [ ] `curl http://localhost:3000/api/health` returns valid JSON after server starts

Closes #76