### PR TITLE
feat(hive-web): MH-005 empty states with guidance

### DIFF
--- a/hive-web/e2e/empty-states.spec.ts
+++ b/hive-web/e2e/empty-states.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * MH-005: Empty states with guidance
+ *
+ * Tests that the Hive UI shows contextual empty/offline states instead of
+ * blank panels, across the room list, agent panel, and daemon-offline scenarios.
+ */
+
+import { test, expect } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Room list empty state (HTTP 200 with empty array — no rooms exist)
+// ---------------------------------------------------------------------------
+
+test.describe('MH-005: Room list — no rooms empty state', () => {
+  test.beforeEach(async ({ page }) => {
+    // Intercept the rooms API to return an empty list
+    await page.route('**/api/rooms', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ rooms: [] }) })
+    );
+    await page.goto('/');
+    // Wait past the 300ms minimum skeleton timer
+    await page.waitForTimeout(400);
+  });
+
+  test('shows "No rooms yet" empty state', async ({ page }) => {
+    const emptyState = page.getByTestId('empty-state');
+    await expect(emptyState).toBeVisible();
+    await expect(emptyState).toContainText('No rooms yet');
+  });
+
+  test('empty state includes contextual description', async ({ page }) => {
+    const emptyState = page.getByTestId('empty-state');
+    await expect(emptyState).toContainText('Create');
+  });
+
+  test('"Create your first room" CTA button is keyboard-focusable', async ({ page }) => {
+    const btn = page.getByRole('button', { name: /create your first room/i });
+    await expect(btn).toBeVisible();
+    await btn.focus();
+    await expect(btn).toBeFocused();
+  });
+
+  test('empty state has accessible role and label', async ({ page }) => {
+    const status = page.getByRole('status');
+    await expect(status).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Room list daemon-offline state (HTTP 503 — daemon unreachable)
+// ---------------------------------------------------------------------------
+
+test.describe('MH-005: Room list — daemon offline state (503)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/rooms', (route) =>
+      route.fulfill({ status: 503, body: 'Service Unavailable' })
+    );
+    await page.goto('/');
+    await page.waitForTimeout(400);
+  });
+
+  test('shows "Daemon offline" empty state', async ({ page }) => {
+    const emptyState = page.getByTestId('empty-state');
+    await expect(emptyState).toBeVisible();
+    await expect(emptyState).toContainText('Daemon offline');
+  });
+
+  test('displays the configured daemon URL', async ({ page }) => {
+    // Default daemon URL is http://localhost:3000
+    const emptyState = page.getByTestId('empty-state');
+    await expect(emptyState).toContainText('localhost:3000');
+  });
+
+  test('"Retry" button is visible and keyboard-focusable', async ({ page }) => {
+    const btn = page.getByRole('button', { name: /retry/i });
+    await expect(btn).toBeVisible();
+    await btn.focus();
+    await expect(btn).toBeFocused();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Room list daemon-offline state (network error — fetch throws)
+// ---------------------------------------------------------------------------
+
+test.describe('MH-005: Room list — daemon offline state (network error)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/rooms', (route) => route.abort('connectionrefused'));
+    await page.goto('/');
+    await page.waitForTimeout(400);
+  });
+
+  test('shows "Daemon offline" empty state on network failure', async ({ page }) => {
+    const emptyState = page.getByTestId('empty-state');
+    await expect(emptyState).toBeVisible();
+    await expect(emptyState).toContainText('Daemon offline');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Loading state is visually distinct (skeleton shown during fetch)
+// ---------------------------------------------------------------------------
+
+test.describe('MH-005: Loading state is distinct from empty state', () => {
+  test('skeleton shown before rooms load, not the empty state', async ({ page }) => {
+    // Delay the rooms response by 500ms so we can observe the loading state
+    await page.route('**/api/rooms', async (route) => {
+      await new Promise((r) => setTimeout(r, 500));
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ rooms: [] }) });
+    });
+    await page.goto('/');
+
+    // During load the empty state must NOT be present
+    const emptyState = page.getByTestId('empty-state');
+    await expect(emptyState).not.toBeVisible();
+
+    // After load completes, the empty state appears
+    await expect(emptyState).toBeVisible({ timeout: 2000 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Agent panel — no agents empty state
+// ---------------------------------------------------------------------------
+
+test.describe('MH-005: Agent panel — no agents empty state', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/rooms', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ rooms: [] }) })
+    );
+    await page.route('**/api/agents', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ agents: [] }) })
+    );
+    await page.goto('/agents');
+    await page.waitForTimeout(400);
+  });
+
+  test('shows "No agents connected" empty state', async ({ page }) => {
+    const emptyState = page.getByTestId('empty-state');
+    await expect(emptyState).toBeVisible();
+    await expect(emptyState).toContainText('No agents connected');
+  });
+
+  test('documentation link is present and keyboard-focusable', async ({ page }) => {
+    const link = page.getByRole('link', { name: /view documentation/i });
+    await expect(link).toBeVisible();
+    await link.focus();
+    await expect(link).toBeFocused();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Agent panel — daemon offline state (network error)
+// ---------------------------------------------------------------------------
+
+test.describe('MH-005: Agent panel — daemon offline state', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/rooms', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ rooms: [] }) })
+    );
+    await page.route('**/api/agents', (route) => route.abort('connectionrefused'));
+    await page.goto('/agents');
+    await page.waitForTimeout(400);
+  });
+
+  test('shows "Daemon offline" empty state', async ({ page }) => {
+    const emptyState = page.getByTestId('empty-state');
+    await expect(emptyState).toBeVisible();
+    await expect(emptyState).toContainText('Daemon offline');
+  });
+
+  test('"Retry" button is visible', async ({ page }) => {
+    const btn = page.getByRole('button', { name: /retry/i });
+    await expect(btn).toBeVisible();
+  });
+});

--- a/hive-web/src/App.tsx
+++ b/hive-web/src/App.tsx
@@ -31,6 +31,14 @@ function StatusDot({ status }: { status: ConnectionStatus }) {
   );
 }
 
+interface RoomsState {
+  loading: boolean;
+  daemonOffline: boolean;
+  rooms: Room[];
+  /** Increment to trigger a re-fetch (e.g. on Retry). */
+  fetchId: number;
+}
+
 function App() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -44,7 +52,18 @@ function App() {
   );
 
   const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
-  const [rooms, setRooms] = useState<Room[]>([]);
+
+  /**
+   * Rooms fetch state. Initial `loading: true` means the skeleton is shown
+   * immediately without any synchronous setState inside the effect.
+   * Increment `fetchId` (outside the effect) to trigger a re-fetch.
+   */
+  const [roomsState, setRoomsState] = useState<RoomsState>({
+    loading: true,
+    daemonOffline: false,
+    rooms: [],
+    fetchId: 0,
+  });
 
   // WebSocket connection to the selected room
   const wsUrl = selectedRoomId ? `${WS_BASE}/ws/${selectedRoomId}` : "";
@@ -53,40 +72,61 @@ function App() {
     autoConnect: !!selectedRoomId,
   });
 
-  // Fetch rooms from backend API on mount
+  // Fetch rooms. All setState calls happen in async callbacks or event handlers
+  // — never synchronously in the effect body — to satisfy react-hooks/set-state-in-effect.
   useEffect(() => {
     let cancelled = false;
+
     fetch(`${API_BASE}/api/rooms`)
-      .then((res) => {
-        if (!res.ok) {
-          console.warn(`Failed to fetch rooms: ${res.status}`);
-          if (!cancelled) setRooms([]);
+      .then(async (res) => {
+        if (cancelled) return;
+        if (res.status === 503) {
+          setRoomsState((s) => ({
+            ...s,
+            loading: false,
+            daemonOffline: true,
+            rooms: [],
+          }));
           return;
         }
-        return res.json();
-      })
-      .then((data) => {
-        if (cancelled || !data) return;
-        const roomList = (data.rooms || data || []) as Array<{
-          id: string;
-          name?: string;
-        }>;
-        setRooms(
-          roomList.map((r) => ({
-            id: r.id || r.name || "",
-            name: r.name || r.id || "",
-            unreadCount: 0,
-          }))
-        );
+        if (!res.ok) {
+          console.warn(`Failed to fetch rooms: ${res.status}`);
+          setRoomsState((s) => ({ ...s, loading: false, rooms: [] }));
+          return;
+        }
+        const data = (await res.json()) as
+          | { rooms?: Array<{ id: string; name?: string }> }
+          | Array<{ id: string; name?: string }>;
+        if (cancelled) return;
+        const raw = Array.isArray(data) ? data : (data.rooms ?? []);
+        const rooms: Room[] = raw.map((r) => ({
+          id: r.id || r.name || "",
+          name: r.name || r.id || "",
+          unreadCount: 0,
+        }));
+        setRoomsState((s) => ({
+          ...s,
+          loading: false,
+          daemonOffline: false,
+          rooms,
+        }));
       })
       .catch((err) => {
         console.warn("Cannot connect to hive-server:", err);
-        if (!cancelled) setRooms([]);
+        if (!cancelled) {
+          setRoomsState((s) => ({
+            ...s,
+            loading: false,
+            daemonOffline: true,
+            rooms: [],
+          }));
+        }
       });
+
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [roomsState.fetchId]);
 
   // Extract members from messages
   const members: Member[] = (() => {
@@ -172,9 +212,20 @@ function App() {
           <div className="flex-1 overflow-y-auto">
             {activeTab === "rooms" ? (
               <RoomList
-                rooms={rooms}
+                rooms={roomsState.rooms}
                 selectedRoomId={selectedRoomId}
                 onSelectRoom={handleSelectRoom}
+                loading={roomsState.loading}
+                daemonOffline={roomsState.daemonOffline}
+                daemonUrl={API_BASE}
+                onRetry={() =>
+                  setRoomsState((s) => ({
+                    ...s,
+                    loading: true,
+                    daemonOffline: false,
+                    fetchId: s.fetchId + 1,
+                  }))
+                }
               />
             ) : (
               <div className="px-3 py-2 text-sm text-gray-500">

--- a/hive-web/src/components/AgentGrid.tsx
+++ b/hive-web/src/components/AgentGrid.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
+import { EmptyState } from './EmptyState';
+import { AgentGridSkeleton } from './Skeleton';
 
 const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
@@ -76,7 +78,7 @@ function AgentCard({ agent }: { agent: Agent }) {
 export function AgentGrid() {
   const [agents, setAgents] = useState<Agent[]>([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [daemonOffline, setDaemonOffline] = useState(false);
 
   const fetchAgents = useCallback(async () => {
     try {
@@ -84,16 +86,18 @@ export function AgentGrid() {
       if (res.ok) {
         const data = await res.json();
         setAgents(data.agents || data || []);
-        setError(null);
-      } else if (res.status === 501) {
+        setDaemonOffline(false);
+      } else if (res.status === 503) {
+        setDaemonOffline(true);
         setAgents([]);
-        setError('Agent management not yet implemented');
       } else {
-        setError(`Failed to fetch agents: ${res.status}`);
+        // 501 (not implemented) or other — show empty, not offline
+        setAgents([]);
+        setDaemonOffline(false);
       }
     } catch {
+      setDaemonOffline(true);
       setAgents([]);
-      setError('Cannot connect to hive-server');
     } finally {
       setLoading(false);
     }
@@ -114,8 +118,21 @@ export function AgentGrid() {
 
   if (loading) {
     return (
-      <div className="flex-1 flex items-center justify-center text-gray-500">
-        Loading agents...
+      <div className="flex-1 overflow-hidden" data-testid="agent-grid">
+        <AgentGridSkeleton />
+      </div>
+    );
+  }
+
+  if (daemonOffline) {
+    return (
+      <div className="flex-1 flex flex-col overflow-hidden" data-testid="agent-grid">
+        <EmptyState
+          icon="🔌"
+          title="Daemon offline"
+          description={`Cannot reach the Hive server at ${API_BASE}. Check that it is running.`}
+          action={{ label: 'Retry', onClick: fetchAgents }}
+        />
       </div>
     );
   }
@@ -153,20 +170,20 @@ export function AgentGrid() {
         )}
       </div>
 
-      {/* Grid */}
-      <div className="flex-1 overflow-y-auto p-4">
-        {error && (
-          <div className="mb-4 px-3 py-2 bg-yellow-900/30 border border-yellow-700 rounded text-sm text-yellow-300">
-            {error}
-          </div>
-        )}
-
-        {agents.length === 0 && !error ? (
-          <div className="flex items-center justify-center h-full text-gray-500 text-sm">
-            No agents running. Use /spawn in a room to start one.
-          </div>
+      {/* Grid or no-agents empty state */}
+      <div className="flex-1 overflow-y-auto">
+        {agents.length === 0 ? (
+          <EmptyState
+            icon="🤖"
+            title="No agents connected"
+            description="No agents are currently registered. Use /spawn in a room to start one."
+            action={{
+              label: 'View documentation',
+              href: 'https://github.com/knoxio/room#agents',
+            }}
+          />
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 p-4">
             {agents.map((agent) => (
               <AgentCard key={agent.username} agent={agent} />
             ))}

--- a/hive-web/src/components/EmptyState.tsx
+++ b/hive-web/src/components/EmptyState.tsx
@@ -1,0 +1,72 @@
+/** Reusable empty-state UI component for panels with no content or degraded state. */
+
+export interface EmptyStateAction {
+  /** Button/link label. */
+  label: string;
+  /** Called when the action button is clicked (renders as a `<button>`). */
+  onClick?: () => void;
+  /** If set, renders as an `<a>` tag opening in a new tab instead of a button. */
+  href?: string;
+}
+
+export interface EmptyStateProps {
+  /** Short heading describing the empty state. */
+  title: string;
+  /** Longer explanation and guidance for the user. */
+  description: string;
+  /** Optional emoji or icon character shown above the title. */
+  icon?: string;
+  /** Optional primary call-to-action. */
+  action?: EmptyStateAction;
+  /** Additional CSS classes applied to the wrapper element. */
+  className?: string;
+}
+
+/**
+ * Centered empty-state panel with title, description, optional icon, and optional CTA.
+ *
+ * Designed to replace blank panels so users always have context on what to do next.
+ */
+export function EmptyState({
+  title,
+  description,
+  icon,
+  action,
+  className = '',
+}: EmptyStateProps) {
+  return (
+    <div
+      className={`flex flex-col items-center justify-center h-full p-6 text-center ${className}`}
+      role="status"
+      aria-label={title}
+      data-testid="empty-state"
+    >
+      {icon && (
+        <span className="text-4xl mb-4" aria-hidden="true">
+          {icon}
+        </span>
+      )}
+      <h3 className="text-base font-semibold text-gray-200 mb-1">{title}</h3>
+      <p className="text-sm text-gray-400 max-w-xs mb-4">{description}</p>
+      {action &&
+        (action.href ? (
+          <a
+            href={action.href}
+            target="_blank"
+            rel="noreferrer"
+            className="px-4 py-2 text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white rounded transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400"
+          >
+            {action.label}
+          </a>
+        ) : (
+          <button
+            type="button"
+            onClick={action.onClick}
+            className="px-4 py-2 text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white rounded transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400"
+          >
+            {action.label}
+          </button>
+        ))}
+    </div>
+  );
+}

--- a/hive-web/src/components/RoomList.tsx
+++ b/hive-web/src/components/RoomList.tsx
@@ -1,4 +1,7 @@
-/** Room list sidebar component (FE-003). */
+/** Room list sidebar component. */
+
+import { EmptyState } from './EmptyState';
+import { RoomListSkeleton } from './Skeleton';
 
 interface Room {
   id: string;
@@ -10,33 +13,78 @@ interface RoomListProps {
   rooms: Room[];
   selectedRoomId: string | null;
   onSelectRoom: (roomId: string) => void;
+  /** True while the room list is being fetched for the first time. */
+  loading?: boolean;
+  /** Set to true when the backend/daemon is unreachable (e.g. 503 or network error). */
+  daemonOffline?: boolean;
+  /** The configured API/daemon URL, shown in the offline state for user verification. */
+  daemonUrl?: string;
+  /** Called when the user clicks "Retry" in the daemon-offline state. */
+  onRetry?: () => void;
+  /** Called when the user clicks "Create your first room" in the no-rooms state. */
+  onCreateRoom?: () => void;
 }
 
-export function RoomList({ rooms, selectedRoomId, onSelectRoom }: RoomListProps) {
+export function RoomList({
+  rooms,
+  selectedRoomId,
+  onSelectRoom,
+  loading = false,
+  daemonOffline = false,
+  daemonUrl,
+  onRetry,
+  onCreateRoom,
+}: RoomListProps) {
+  if (loading) {
+    return <RoomListSkeleton />;
+  }
+
+  if (daemonOffline) {
+    return (
+      <EmptyState
+        icon="🔌"
+        title="Daemon offline"
+        description={
+          daemonUrl
+            ? `Cannot reach the Hive server at ${daemonUrl}. Check that it is running.`
+            : 'Cannot reach the Hive server. Check that it is running.'
+        }
+        action={onRetry ? { label: 'Retry', onClick: onRetry } : undefined}
+      />
+    );
+  }
+
   if (rooms.length === 0) {
     return (
-      <div className="p-3 text-sm text-gray-500">
-        No rooms available
-      </div>
+      <EmptyState
+        icon="💬"
+        title="No rooms yet"
+        description="Create a room to start collaborating with your agents."
+        action={
+          onCreateRoom
+            ? { label: 'Create your first room', onClick: onCreateRoom }
+            : undefined
+        }
+      />
     );
   }
 
   return (
-    <ul className="space-y-0.5 px-2">
+    <ul className="space-y-0.5 px-2" role="list" aria-label="Rooms">
       {rooms.map((room) => (
         <li key={room.id}>
           <button
             onClick={() => onSelectRoom(room.id)}
             className={`w-full text-left px-3 py-2 rounded text-sm transition-colors flex items-center justify-between ${
               selectedRoomId === room.id
-                ? "bg-blue-600/20 text-blue-300"
-                : "text-gray-400 hover:bg-gray-700 hover:text-gray-200"
+                ? 'bg-blue-600/20 text-blue-300'
+                : 'text-gray-400 hover:bg-gray-700 hover:text-gray-200'
             }`}
           >
             <span className="truncate">#{room.name}</span>
             {room.unreadCount > 0 && (
               <span className="ml-2 px-1.5 py-0.5 text-xs rounded-full bg-blue-600 text-white min-w-[1.25rem] text-center">
-                {room.unreadCount > 99 ? "99+" : room.unreadCount}
+                {room.unreadCount > 99 ? '99+' : room.unreadCount}
               </span>
             )}
           </button>

--- a/hive-web/src/components/Skeleton.tsx
+++ b/hive-web/src/components/Skeleton.tsx
@@ -61,3 +61,24 @@ export function MemberSkeleton() {
     </div>
   );
 }
+
+/** Skeleton for the agent grid (3-column card layout). */
+export function AgentGridSkeleton() {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 p-4">
+      {[...Array(6)].map((_, i) => (
+        <div key={i} className="bg-gray-800 border border-gray-700 rounded-lg p-4 space-y-3">
+          <div className="flex items-center gap-2">
+            <SkeletonBar className="w-8 h-8 rounded-full shrink-0" />
+            <div className="flex-1 space-y-1">
+              <SkeletonBar className="h-4 w-3/4" />
+              <SkeletonBar className="h-3 w-1/2" />
+            </div>
+          </div>
+          <SkeletonBar className="h-3 w-full" />
+          <SkeletonBar className="h-3 w-2/3" />
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- New `EmptyState` component — reusable, accessible, keyboard-focusable CTA
- `RoomList`: skeleton while loading → "No rooms yet" + CTA (empty), or "Daemon offline" + Retry (503/network error); shows daemon URL
- `AgentGrid`: skeleton while loading → "No agents connected" + docs link, or "Daemon offline" + Retry
- `App`: rooms fetch refactored to a single `RoomsState` object; `loading: true` in initial state avoids synchronous setState inside the effect body (`react-hooks/set-state-in-effect`)
- `Skeleton`: `AgentGridSkeleton` added
- `e2e/empty-states.spec.ts`: Playwright tests covering all MH-005 acceptance criteria

## Test plan

- [ ] `eslint src/` + `tsc -b` — both clean
- [ ] `npx playwright test e2e/empty-states.spec.ts`
- [ ] Manual: mock 503 on `/api/rooms` → daemon offline state with URL + Retry
- [ ] Manual: mock 200 `{rooms:[]}` → "No rooms yet" CTA visible
- [ ] Manual: `/agents` with empty response → "No agents connected" + docs link
- [ ] Accessibility: Tab reaches all CTA buttons/links