### PR TITLE
feat(hive-web): MH-007 login page — auth form, JWT storage, route guard

### DIFF
--- a/hive-web/e2e/login.spec.ts
+++ b/hive-web/e2e/login.spec.ts
@@ -1,0 +1,238 @@
+/**
+ * MH-007: Login page wired into router.
+ *
+ * Tests use mocked /api/auth/login responses so they do not require a running
+ * backend.  localStorage is cleared before each test to ensure a clean state.
+ */
+
+import { test, expect } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Mock a successful login response. */
+async function mockLoginSuccess(page: import('@playwright/test').Page, token = 'test-jwt-token') {
+  await page.route('**/api/auth/login', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        token,
+        expires_at: new Date(Date.now() + 86400_000).toISOString(),
+        user: { username: 'admin', role: 'admin' },
+      }),
+    }),
+  );
+}
+
+/** Mock a failed (401) login response. */
+async function mockLoginFailure(page: import('@playwright/test').Page) {
+  await page.route('**/api/auth/login', (route) =>
+    route.fulfill({
+      status: 401,
+      contentType: 'application/json',
+      body: JSON.stringify({ code: 'invalid_credentials', message: 'bad credentials' }),
+    }),
+  );
+}
+
+/** Clear auth token from localStorage. */
+async function clearAuth(page: import('@playwright/test').Page) {
+  await page.evaluate(() => localStorage.removeItem('hive-auth-token'));
+}
+
+/** Set a fake auth token in localStorage. */
+async function setAuth(page: import('@playwright/test').Page, token = 'existing-token') {
+  await page.evaluate((t) => localStorage.setItem('hive-auth-token', t), token);
+}
+
+// ---------------------------------------------------------------------------
+// MH-007 — Login page renders
+// ---------------------------------------------------------------------------
+
+test.describe('MH-007: Login page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/login');
+    await clearAuth(page);
+  });
+
+  test('login page renders at /login', async ({ page }) => {
+    await page.goto('/login');
+    await expect(page.getByTestId('login-page')).toBeVisible();
+  });
+
+  test('login form has username and password fields', async ({ page }) => {
+    await page.goto('/login');
+    await expect(page.getByTestId('login-username')).toBeVisible();
+    await expect(page.getByTestId('login-password')).toBeVisible();
+  });
+
+  test('login form has a submit button', async ({ page }) => {
+    await page.goto('/login');
+    await expect(page.getByTestId('login-submit')).toBeVisible();
+  });
+
+  test('submit button is disabled when fields are empty', async ({ page }) => {
+    await page.goto('/login');
+    await expect(page.getByTestId('login-submit')).toBeDisabled();
+  });
+
+  test('submit button enables when both fields are filled', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByTestId('login-username').fill('admin');
+    await page.getByTestId('login-password').fill('secret');
+    await expect(page.getByTestId('login-submit')).toBeEnabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MH-007 — Show/hide password toggle
+// ---------------------------------------------------------------------------
+
+test.describe('MH-007: Password show/hide toggle', () => {
+  test('password field is hidden by default', async ({ page }) => {
+    await page.goto('/login');
+    await expect(page.getByTestId('login-password')).toHaveAttribute('type', 'password');
+  });
+
+  test('toggle reveals password', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByTestId('login-password').fill('secret');
+    await page.getByTestId('login-toggle-password').click();
+    await expect(page.getByTestId('login-password')).toHaveAttribute('type', 'text');
+  });
+
+  test('toggle hides password again on second click', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByTestId('login-toggle-password').click();
+    await page.getByTestId('login-toggle-password').click();
+    await expect(page.getByTestId('login-password')).toHaveAttribute('type', 'password');
+  });
+
+  test('toggle button is keyboard-focusable', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByTestId('login-toggle-password').focus();
+    await expect(page.getByTestId('login-toggle-password')).toBeFocused();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MH-007 — Successful login flow
+// ---------------------------------------------------------------------------
+
+test.describe('MH-007: Successful login', () => {
+  test('successful login stores token and navigates to /', async ({ page }) => {
+    await clearAuth(page);
+    await mockLoginSuccess(page, 'my-jwt');
+    await page.route('**/api/rooms', (r) =>
+      r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ rooms: [] }) }),
+    );
+
+    await page.goto('/login');
+    await page.getByTestId('login-username').fill('admin');
+    await page.getByTestId('login-password').fill('password');
+    await page.getByTestId('login-submit').click();
+
+    await expect(page).toHaveURL('/');
+    const token = await page.evaluate(() => localStorage.getItem('hive-auth-token'));
+    expect(token).toBe('my-jwt');
+  });
+
+  test('login form shows loading state while request is in flight', async ({ page }) => {
+    await clearAuth(page);
+    let resolveRoute: () => void;
+    await page.route('**/api/auth/login', async (route) => {
+      await new Promise<void>((resolve) => { resolveRoute = resolve; });
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ token: 't', expires_at: '', user: { username: 'a', role: 'a' } }),
+      });
+    });
+
+    await page.goto('/login');
+    await page.getByTestId('login-username').fill('admin');
+    await page.getByTestId('login-password').fill('password');
+    await page.getByTestId('login-submit').click();
+
+    // During the in-flight request, button should be disabled / show loading text
+    await expect(page.getByTestId('login-submit')).toBeDisabled();
+    await expect(page.getByTestId('login-submit')).toContainText('Signing in');
+
+    // Resolve the request so the test can clean up
+    resolveRoute!();
+  });
+
+  test('Enter key submits the form', async ({ page }) => {
+    await clearAuth(page);
+    await mockLoginSuccess(page);
+    await page.route('**/api/rooms', (r) =>
+      r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ rooms: [] }) }),
+    );
+
+    await page.goto('/login');
+    await page.getByTestId('login-username').fill('admin');
+    await page.getByTestId('login-password').fill('password');
+    await page.getByTestId('login-password').press('Enter');
+
+    await expect(page).toHaveURL('/');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MH-007 — Failed login
+// ---------------------------------------------------------------------------
+
+test.describe('MH-007: Failed login', () => {
+  test('failed login shows inline error without clearing username', async ({ page }) => {
+    await clearAuth(page);
+    await mockLoginFailure(page);
+
+    await page.goto('/login');
+    await page.getByTestId('login-username').fill('admin');
+    await page.getByTestId('login-password').fill('wrongpassword');
+    await page.getByTestId('login-submit').click();
+
+    // Error shown
+    const error = page.getByTestId('login-error');
+    await expect(error).toBeVisible();
+    await expect(error).toContainText('Invalid username or password');
+
+    // Username not cleared
+    await expect(page.getByTestId('login-username')).toHaveValue('admin');
+
+    // Still on /login
+    await expect(page).toHaveURL('/login');
+  });
+
+  test('password field is cleared after failed login', async ({ page }) => {
+    await clearAuth(page);
+    await mockLoginFailure(page);
+
+    await page.goto('/login');
+    await page.getByTestId('login-username').fill('admin');
+    await page.getByTestId('login-password').fill('wrongpassword');
+    await page.getByTestId('login-submit').click();
+
+    await expect(page.getByTestId('login-password')).toHaveValue('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MH-007 — Already authenticated redirect
+// ---------------------------------------------------------------------------
+
+test.describe('MH-007: Already authenticated redirect', () => {
+  test('navigating to /login when already authed redirects to /', async ({ page }) => {
+    // Set a token before navigating
+    await page.goto('/login');
+    await setAuth(page);
+    await page.route('**/api/rooms', (r) =>
+      r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ rooms: [] }) }),
+    );
+
+    await page.goto('/login');
+    await expect(page).toHaveURL('/');
+  });
+});

--- a/hive-web/src/components/LoginPage.tsx
+++ b/hive-web/src/components/LoginPage.tsx
@@ -1,90 +1,198 @@
-import { useState } from 'react';
+/**
+ * Login page at /login (MH-007).
+ *
+ * Username + password form that calls POST /api/auth/login, stores the
+ * returned JWT, and redirects to the originally requested URL (or /).
+ */
 
-interface LoginPageProps {
-  onLogin: () => void;
+import { type FormEvent, useState } from 'react';
+import { Navigate, useLocation, useNavigate } from 'react-router-dom';
+import { isAuthenticated, setToken } from '../lib/auth';
+import { FieldError } from './FieldError';
+
+const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
+interface LoginResponse {
+  token: string;
+  expires_at: string;
+  user: { username: string; role: string };
 }
 
-export function LoginPage({ onLogin }: LoginPageProps) {
-  const [serverUrl, setServerUrl] = useState(
-    localStorage.getItem('hive-server-url') || 'http://localhost:3000'
-  );
-  const [error, setError] = useState('');
+/**
+ * Login page.
+ *
+ * Accessible at /login (no auth required).  Already-authenticated users are
+ * redirected immediately to the dashboard.
+ */
+export function LoginPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  // Already logged in → go straight to the dashboard
+  if (isAuthenticated()) {
+    return <Navigate to="/" replace />;
+  }
+
+  // After login, restore the originally requested URL or fall back to /
+  const from = (location.state as { from?: Location } | null)?.from?.pathname ?? '/';
+
+  return <LoginForm from={from} navigate={navigate} />;
+}
+
+// ---------------------------------------------------------------------------
+// Inner form component — separated to allow hooks after the auth redirect guard
+// ---------------------------------------------------------------------------
+
+interface LoginFormProps {
+  from: string;
+  navigate: ReturnType<typeof useNavigate>;
+}
+
+function LoginForm({ from, navigate }: LoginFormProps) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  const handleConnect = async () => {
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
     setLoading(true);
-    setError('');
+    setError(null);
+
     try {
-      const resp = await fetch(`${serverUrl}/api/health`);
-      if (!resp.ok) throw new Error(`Server returned ${resp.status}`);
-      const data = await resp.json();
-      if (data.status === 'ok' || data.status === 'degraded') {
-        localStorage.setItem('hive-server-url', serverUrl);
-        onLogin();
-      } else {
-        setError('Server is not ready');
+      const res = await fetch(`${API_BASE}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      });
+
+      if (res.ok) {
+        const data: LoginResponse = await res.json();
+        setToken(data.token);
+        navigate(from, { replace: true });
+        return;
       }
-    } catch (e) {
-      setError(`Cannot connect to ${serverUrl}: ${e instanceof Error ? e.message : 'unknown error'}`);
+
+      // Failed login — keep username, clear password, show error
+      setPassword('');
+      if (res.status === 401) {
+        setError('Invalid username or password.');
+      } else if (res.status === 429) {
+        setError('Too many login attempts — please wait a moment.');
+      } else {
+        setError('Login failed. Please try again.');
+      }
+    } catch {
+      setError('Could not reach the server — check your connection.');
     } finally {
       setLoading(false);
     }
   };
 
   return (
-    <div className="min-h-screen bg-gray-900 flex items-center justify-center">
-      <div className="bg-gray-800 rounded-lg shadow-xl p-8 w-full max-w-md">
-        <h1 className="text-2xl font-bold text-white mb-2">Hive</h1>
-        <p className="text-gray-400 mb-6">Agent Orchestration Platform</p>
+    <div
+      className="min-h-screen bg-gray-900 flex items-center justify-center px-4"
+      data-testid="login-page"
+    >
+      <div className="bg-gray-800 rounded-lg shadow-xl p-8 w-full max-w-sm">
+        {/* Header */}
+        <h1 className="text-2xl font-bold text-white mb-1">Hive</h1>
+        <p className="text-gray-400 text-sm mb-6">Sign in to continue</p>
 
-        <div className="space-y-4">
+        <form onSubmit={handleSubmit} noValidate className="space-y-4">
+          {/* Username */}
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-1">
-              Server URL
+            <label
+              htmlFor="login-username"
+              className="block text-sm font-medium text-gray-300 mb-1"
+            >
+              Username
             </label>
             <input
-              type="url"
-              value={serverUrl}
-              onChange={(e) => setServerUrl(e.target.value)}
+              id="login-username"
+              type="text"
+              autoComplete="username"
+              autoFocus
+              required
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              data-testid="login-username"
               className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-              placeholder="http://localhost:3000"
+              placeholder="your-username"
             />
           </div>
 
-          {error && (
-            <div className="bg-red-900/50 border border-red-700 rounded-md px-3 py-2 text-red-300 text-sm">
-              {error}
-            </div>
-          )}
-
-          <button
-            onClick={handleConnect}
-            disabled={loading}
-            className="w-full py-2 px-4 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-800 disabled:cursor-not-allowed text-white font-medium rounded-md transition-colors"
-          >
-            {loading ? 'Connecting...' : 'Connect'}
-          </button>
-
-          <div className="relative">
-            <div className="absolute inset-0 flex items-center">
-              <div className="w-full border-t border-gray-600" />
-            </div>
-            <div className="relative flex justify-center text-sm">
-              <span className="px-2 bg-gray-800 text-gray-400">or</span>
+          {/* Password */}
+          <div>
+            <label
+              htmlFor="login-password"
+              className="block text-sm font-medium text-gray-300 mb-1"
+            >
+              Password
+            </label>
+            <div className="relative">
+              <input
+                id="login-password"
+                type={showPassword ? 'text' : 'password'}
+                autoComplete="current-password"
+                required
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                data-testid="login-password"
+                className="w-full px-3 py-2 pr-10 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                placeholder="••••••••"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((v) => !v)}
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+                data-testid="login-toggle-password"
+                className="absolute inset-y-0 right-0 px-3 flex items-center text-gray-400 hover:text-gray-200 focus:outline-none focus:text-gray-200"
+              >
+                {showPassword ? (
+                  // Eye-off icon
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94" />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19" />
+                    <line x1="1" y1="1" x2="23" y2="23" strokeLinecap="round" />
+                  </svg>
+                ) : (
+                  // Eye icon
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                    <circle cx="12" cy="12" r="3" />
+                  </svg>
+                )}
+              </button>
             </div>
           </div>
 
-          <button
-            onClick={onLogin}
-            className="w-full py-2 px-4 bg-gray-700 hover:bg-gray-600 text-gray-300 font-medium rounded-md transition-colors"
-          >
-            Continue as Guest
-          </button>
-        </div>
+          {/* Inline error */}
+          <FieldError message={error} data-testid="login-error" />
 
-        <p className="mt-6 text-center text-xs text-gray-500">
-          OAuth login coming soon
-        </p>
+          {/* Submit */}
+          <button
+            type="submit"
+            disabled={loading || !username || !password}
+            data-testid="login-submit"
+            className="w-full py-2 px-4 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-800 disabled:cursor-not-allowed text-white font-medium rounded-md transition-colors flex items-center justify-center gap-2"
+          >
+            {loading && (
+              <svg
+                aria-hidden="true"
+                className="animate-spin h-4 w-4 text-white"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+              </svg>
+            )}
+            {loading ? 'Signing in…' : 'Sign in'}
+          </button>
+        </form>
       </div>
     </div>
   );

--- a/hive-web/src/components/RequireAuth.tsx
+++ b/hive-web/src/components/RequireAuth.tsx
@@ -1,0 +1,30 @@
+/**
+ * Route guard that redirects unauthenticated users to /login (MH-007).
+ *
+ * Saves the current location so LoginPage can restore it after a successful
+ * login (the `state.from` pattern).
+ */
+
+import { type ReactNode } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { isAuthenticated } from '../lib/auth';
+
+interface RequireAuthProps {
+  children: ReactNode;
+}
+
+/**
+ * Wrap protected routes with RequireAuth.
+ *
+ * @example
+ * <Route path="/*" element={<RequireAuth><App /></RequireAuth>} />
+ */
+export function RequireAuth({ children }: RequireAuthProps) {
+  const location = useLocation();
+
+  if (!isAuthenticated()) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/hive-web/src/lib/auth.ts
+++ b/hive-web/src/lib/auth.ts
@@ -1,0 +1,37 @@
+/**
+ * Client-side auth token management (MH-007).
+ *
+ * Stores the JWT in localStorage so it survives page reloads.  The token is
+ * read on every request — there is no in-memory cache to keep in sync.
+ */
+
+const TOKEN_KEY = 'hive-auth-token';
+
+/** Retrieve the stored JWT, or null if not authenticated. */
+export function getToken(): string | null {
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+/** Persist a JWT after successful login. */
+export function setToken(token: string): void {
+  localStorage.setItem(TOKEN_KEY, token);
+}
+
+/** Remove the stored JWT (logout). */
+export function clearToken(): void {
+  localStorage.removeItem(TOKEN_KEY);
+}
+
+/** Return true when a token is present (does not validate signature/expiry). */
+export function isAuthenticated(): boolean {
+  return getToken() !== null;
+}
+
+/**
+ * Build an Authorization header value from the stored token.
+ * Returns undefined when no token is present.
+ */
+export function authHeader(): Record<string, string> {
+  const token = getToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}

--- a/hive-web/src/main.tsx
+++ b/hive-web/src/main.tsx
@@ -1,15 +1,30 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
+import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
 import { ErrorBoundary } from './components/ErrorBoundary.tsx'
+import { LoginPage } from './components/LoginPage.tsx'
+import { RequireAuth } from './components/RequireAuth.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
       <ErrorBoundary>
-        <App />
+        <Routes>
+          {/* Public — no auth required */}
+          <Route path="/login" element={<LoginPage />} />
+
+          {/* Protected — redirect to /login when no token */}
+          <Route
+            path="/*"
+            element={
+              <RequireAuth>
+                <App />
+              </RequireAuth>
+            }
+          />
+        </Routes>
       </ErrorBoundary>
     </BrowserRouter>
   </StrictMode>,


### PR DESCRIPTION
## Summary
- `LoginPage` at `/login`: username + password fields, show/hide toggle, Enter-key submit, loading spinner, inline error on failure (username preserved, password cleared)
- `auth.ts`: localStorage token management (`getToken`/`setToken`/`clearToken`/`isAuthenticated`/`authHeader`)
- `RequireAuth`: route guard redirecting unauthenticated users to `/login` with `state.from` for post-login redirect
- `main.tsx`: React Router `<Routes>` — `/login` public, `/*` protected via `RequireAuth`
- Already-authenticated users at `/login` are redirected to `/`

## Auth API
Calls `POST /api/auth/login` with `{ username, password }`, expects `{ token, expires_at, user }`. JWT stored in `localStorage`.

## Tests (Playwright e2e — `hive-web/e2e/login.spec.ts`, 14 tests)
- Login page renders at `/login` with all form elements
- Submit disabled when empty, enabled when both fields filled
- Password type is `password` by default; toggle reveals/hides
- Show/hide toggle keyboard-focusable
- Successful login stores JWT and navigates to `/`
- Loading state shown during in-flight request (button disabled + spinner)
- Enter key submits form
- Failed 401: inline error shown, username preserved, password cleared
- Already-authed `/login` → redirect to `/`

## Checklist
- [x] Playwright tests validate MH-007 acceptance criteria
- [x] TypeScript compiles cleanly
- [x] ESLint passes
- [x] Verified docs/README are accurate after this change (no drift)

> **Note:** PR is open but merge should follow tb-112 (MH-013 auth backend) per ba's coordination note.

Closes tb-111 / MH-007