### PR TITLE
feat(hive-server): MH-029 app config — daemon_url editable via API

### DIFF
--- a/crates/hive-server/src/db.rs
+++ b/crates/hive-server/src/db.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 use rusqlite::Connection;
 
 /// Schema version — bump when adding new migrations.
-const SCHEMA_VERSION: i64 = 1;
+const SCHEMA_VERSION: i64 = 2;
 
 /// SQL statements for schema v1.
 const SCHEMA_V1: &str = r#"
@@ -58,6 +58,35 @@ CREATE TABLE IF NOT EXISTS team_manifests (
     updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
 );
 "#;
+
+/// SQL statements for schema v2 — app settings and change history.
+const SCHEMA_V2: &str = r#"
+CREATE TABLE IF NOT EXISTS app_settings (
+    key        TEXT PRIMARY KEY,
+    value      TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS app_settings_history (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    key        TEXT NOT NULL,
+    old_value  TEXT,
+    new_value  TEXT NOT NULL,
+    changed_by TEXT NOT NULL DEFAULT 'system',
+    changed_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+"#;
+
+/// A row from `app_settings_history`.
+#[derive(Debug, Clone)]
+pub struct SettingHistoryRow {
+    pub id: i64,
+    pub key: String,
+    pub old_value: Option<String>,
+    pub new_value: String,
+    pub changed_by: String,
+    pub changed_at: String,
+}
 
 /// Thread-safe database handle.
 ///
@@ -120,6 +149,12 @@ impl Database {
             tracing::info!("database migrated to schema v1");
         }
 
+        if current < 2 {
+            conn.execute_batch(SCHEMA_V2)?;
+            conn.execute("INSERT INTO _migrations (version) VALUES (2)", [])?;
+            tracing::info!("database migrated to schema v2");
+        }
+
         let final_version: i64 = conn.query_row(
             "SELECT COALESCE(MAX(version), 0) FROM _migrations",
             [],
@@ -139,6 +174,90 @@ impl Database {
     {
         let conn = self.conn.lock().expect("db lock poisoned");
         f(&conn)
+    }
+
+    /// Return the current value for `key`, or `None` if not set.
+    pub fn get_setting(&self, key: &str) -> Result<Option<String>, rusqlite::Error> {
+        self.with_conn(|conn| {
+            match conn.query_row(
+                "SELECT value FROM app_settings WHERE key = ?1",
+                [key],
+                |row| row.get(0),
+            ) {
+                Ok(v) => Ok(Some(v)),
+                Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+                Err(e) => Err(e),
+            }
+        })
+    }
+
+    /// Upsert a setting value and record the change in `app_settings_history`.
+    ///
+    /// `changed_by` should be a username or `"system"` for automatic changes.
+    pub fn set_setting(
+        &self,
+        key: &str,
+        value: &str,
+        changed_by: &str,
+    ) -> Result<(), rusqlite::Error> {
+        self.with_conn(|conn| {
+            let old_value: Option<String> = match conn.query_row(
+                "SELECT value FROM app_settings WHERE key = ?1",
+                [key],
+                |row| row.get(0),
+            ) {
+                Ok(v) => Some(v),
+                Err(rusqlite::Error::QueryReturnedNoRows) => None,
+                Err(e) => return Err(e),
+            };
+
+            let updated = conn.execute(
+                "UPDATE app_settings SET value = ?1, updated_at = datetime('now') WHERE key = ?2",
+                rusqlite::params![value, key],
+            )?;
+            if updated == 0 {
+                conn.execute(
+                    "INSERT INTO app_settings (key, value, updated_at) VALUES (?1, ?2, datetime('now'))",
+                    rusqlite::params![key, value],
+                )?;
+            }
+
+            conn.execute(
+                "INSERT INTO app_settings_history (key, old_value, new_value, changed_by)
+                 VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![key, old_value, value, changed_by],
+            )?;
+
+            Ok(())
+        })
+    }
+
+    /// Return the last `limit` history entries for `key`, newest first.
+    pub fn get_setting_history(
+        &self,
+        key: &str,
+        limit: i64,
+    ) -> Result<Vec<SettingHistoryRow>, rusqlite::Error> {
+        self.with_conn(|conn| {
+            let mut stmt = conn.prepare(
+                "SELECT id, key, old_value, new_value, changed_by, changed_at
+                 FROM app_settings_history
+                 WHERE key = ?1
+                 ORDER BY changed_at DESC, id DESC
+                 LIMIT ?2",
+            )?;
+            let rows = stmt.query_map(rusqlite::params![key, limit], |row| {
+                Ok(SettingHistoryRow {
+                    id: row.get(0)?,
+                    key: row.get(1)?,
+                    old_value: row.get(2)?,
+                    new_value: row.get(3)?,
+                    changed_by: row.get(4)?,
+                    changed_at: row.get(5)?,
+                })
+            })?;
+            rows.collect()
+        })
     }
 }
 
@@ -160,6 +279,8 @@ mod tests {
             assert!(names.contains(&"workspace_rooms".to_owned()));
             assert!(names.contains(&"api_keys".to_owned()));
             assert!(names.contains(&"team_manifests".to_owned()));
+            assert!(names.contains(&"app_settings".to_owned()));
+            assert!(names.contains(&"app_settings_history".to_owned()));
             assert!(names.contains(&"_migrations".to_owned()));
             Ok(())
         })
@@ -176,7 +297,7 @@ mod tests {
         db.with_conn(|conn| {
             let version: i64 =
                 conn.query_row("SELECT MAX(version) FROM _migrations", [], |row| row.get(0))?;
-            assert_eq!(version, 1);
+            assert_eq!(version, 2);
             Ok(())
         })
         .unwrap();
@@ -303,6 +424,29 @@ mod tests {
             Ok(())
         })
         .unwrap();
+    }
+
+    #[test]
+    fn setting_set_and_get() {
+        let db = Database::open_memory().unwrap();
+        assert!(db.get_setting("daemon_url").unwrap().is_none());
+
+        db.set_setting("daemon_url", "ws://first:4200", "system")
+            .unwrap();
+        assert_eq!(
+            db.get_setting("daemon_url").unwrap().as_deref(),
+            Some("ws://first:4200")
+        );
+
+        db.set_setting("daemon_url", "ws://second:4200", "admin")
+            .unwrap();
+        assert_eq!(
+            db.get_setting("daemon_url").unwrap().as_deref(),
+            Some("ws://second:4200")
+        );
+
+        let history = db.get_setting_history("daemon_url", 10).unwrap();
+        assert_eq!(history.len(), 2);
     }
 
     #[test]

--- a/crates/hive-server/src/main.rs
+++ b/crates/hive-server/src/main.rs
@@ -4,6 +4,7 @@ pub mod daemon;
 pub mod db;
 pub mod error;
 mod rest_proxy;
+mod settings;
 mod ws_relay;
 
 use std::path::PathBuf;
@@ -93,6 +94,17 @@ async fn main() {
     let bind_addr = format!("{}:{}", config.server.host, config.server.port);
     tracing::info!("hive-server starting on {bind_addr}");
 
+    // Seed daemon_url into app_settings on first run (no-op if already set).
+    match db.get_setting("daemon_url") {
+        Ok(None) => {
+            if let Err(e) = db.set_setting("daemon_url", &config.daemon.ws_url, "system") {
+                tracing::warn!("failed to seed daemon_url setting: {e}");
+            }
+        }
+        Ok(Some(_)) => {} // already configured — preserve the stored value
+        Err(e) => tracing::warn!("failed to read daemon_url setting: {e}"),
+    }
+
     let state = Arc::new(AppState {
         config,
         db,
@@ -110,6 +122,11 @@ async fn main() {
         )
         .route("/api/rooms/{room_id}/send", post(rest_proxy::send_message))
         .route("/ws/{room_id}", get(ws_relay::ws_handler))
+        .route(
+            "/api/settings",
+            get(settings::get_settings).patch(settings::patch_settings),
+        )
+        .route("/api/settings/history", get(settings::get_settings_history))
         .with_state(state)
         .layer(
             CorsLayer::new()

--- a/crates/hive-server/src/settings.rs
+++ b/crates/hive-server/src/settings.rs
@@ -1,0 +1,251 @@
+//! App settings API — MH-029.
+//!
+//! Provides `GET /api/settings`, `PATCH /api/settings`, and
+//! `GET /api/settings/history` endpoints. Settings are persisted in the
+//! `app_settings` SQLite table; every change is audited in
+//! `app_settings_history`.
+//!
+//! Admin-only restriction is a placeholder; full enforcement requires
+//! MH-013 (basic token auth) which is implemented in Wave 2.
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{db::SettingHistoryRow, error::HiveError, AppState};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// All editable app settings returned by `GET /api/settings`.
+#[derive(Debug, Serialize)]
+pub struct AppSettings {
+    /// WebSocket URL of the room daemon (e.g. `ws://127.0.0.1:4200`).
+    pub daemon_url: String,
+}
+
+/// Request body for `PATCH /api/settings`.
+#[derive(Debug, Deserialize)]
+pub struct PatchSettingsRequest {
+    /// New daemon WebSocket URL. Must be a valid `ws://`, `wss://`,
+    /// `http://`, or `https://` URL.
+    pub daemon_url: Option<String>,
+}
+
+/// A single entry in the settings change log.
+#[derive(Debug, Serialize)]
+pub struct SettingHistoryItem {
+    pub id: i64,
+    pub key: String,
+    pub old_value: Option<String>,
+    pub new_value: String,
+    pub changed_by: String,
+    pub changed_at: String,
+}
+
+impl From<SettingHistoryRow> for SettingHistoryItem {
+    fn from(r: SettingHistoryRow) -> Self {
+        Self {
+            id: r.id,
+            key: r.key,
+            old_value: r.old_value,
+            new_value: r.new_value,
+            changed_by: r.changed_by,
+            changed_at: r.changed_at,
+        }
+    }
+}
+
+/// Query parameters for `GET /api/settings/history`.
+#[derive(Debug, Deserialize)]
+pub struct HistoryQuery {
+    pub key: Option<String>,
+    pub limit: Option<i64>,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DAEMON_URL_KEY: &str = "daemon_url";
+
+/// Valid URL schemes for the daemon URL.
+const VALID_SCHEMES: &[&str] = &["ws", "wss", "http", "https"];
+
+/// Validate a daemon URL: must parse as a URL and have an accepted scheme.
+fn validate_daemon_url(raw: &str) -> Result<(), HiveError> {
+    let parsed = reqwest::Url::parse(raw)
+        .map_err(|_| HiveError::BadRequest(format!("invalid URL: {raw}")))?;
+
+    if !VALID_SCHEMES.contains(&parsed.scheme()) {
+        return Err(HiveError::BadRequest(format!(
+            "invalid scheme '{}': must be one of ws, wss, http, https",
+            parsed.scheme()
+        )));
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// `GET /api/settings` — return current app configuration.
+pub async fn get_settings(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<AppSettings>, HiveError> {
+    let db = state.db.clone();
+    let daemon_url = tokio::task::spawn_blocking(move || db.get_setting(DAEMON_URL_KEY))
+        .await
+        .map_err(|e| HiveError::Internal(e.to_string()))?
+        .map_err(|e| HiveError::Internal(e.to_string()))?
+        .unwrap_or_else(|| state.config.daemon.ws_url.clone());
+
+    Ok(Json(AppSettings { daemon_url }))
+}
+
+/// `PATCH /api/settings` — update editable settings.
+///
+/// Returns the updated settings on success. Restricted to admin users
+/// (enforcement pending MH-013).
+pub async fn patch_settings(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<PatchSettingsRequest>,
+) -> Result<(StatusCode, Json<AppSettings>), HiveError> {
+    if body.daemon_url.is_none() {
+        return Err(HiveError::BadRequest("no fields to update".to_owned()));
+    }
+
+    if let Some(ref url) = body.daemon_url {
+        validate_daemon_url(url)?;
+    }
+
+    let db = state.db.clone();
+    let url = body.daemon_url.unwrap();
+    let url_for_block = url.clone();
+
+    tokio::task::spawn_blocking(move || db.set_setting(DAEMON_URL_KEY, &url_for_block, "system"))
+        .await
+        .map_err(|e| HiveError::Internal(e.to_string()))?
+        .map_err(|e| HiveError::Internal(e.to_string()))?;
+
+    // Best-effort WS broadcast — full reconnect wiring requires MH-027.
+    tracing::info!(daemon_url = %url, "settings_changed: daemon_url updated");
+
+    Ok((StatusCode::OK, Json(AppSettings { daemon_url: url })))
+}
+
+/// `GET /api/settings/history` — return change log for a settings key.
+///
+/// Query params:
+/// - `key` (default: `daemon_url`)
+/// - `limit` (default: 5, max: 100)
+pub async fn get_settings_history(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<HistoryQuery>,
+) -> Result<Json<Vec<SettingHistoryItem>>, HiveError> {
+    let key = params.key.unwrap_or_else(|| DAEMON_URL_KEY.to_owned());
+    let limit = params.limit.unwrap_or(5).clamp(1, 100);
+
+    let db = state.db.clone();
+    let rows = tokio::task::spawn_blocking(move || db.get_setting_history(&key, limit))
+        .await
+        .map_err(|e| HiveError::Internal(e.to_string()))?
+        .map_err(|e| HiveError::Internal(e.to_string()))?;
+
+    Ok(Json(rows.into_iter().map(Into::into).collect()))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_ws_url_accepted() {
+        assert!(validate_daemon_url("ws://127.0.0.1:4200").is_ok());
+        assert!(validate_daemon_url("wss://daemon.example.com").is_ok());
+        assert!(validate_daemon_url("http://localhost:4200").is_ok());
+        assert!(validate_daemon_url("https://daemon.example.com/api").is_ok());
+    }
+
+    #[test]
+    fn bare_hostname_rejected() {
+        assert!(validate_daemon_url("localhost:4200").is_err());
+        assert!(validate_daemon_url("daemon.example.com").is_err());
+    }
+
+    #[test]
+    fn unsupported_scheme_rejected() {
+        assert!(validate_daemon_url("ftp://example.com").is_err());
+        assert!(validate_daemon_url("tcp://127.0.0.1:4200").is_err());
+    }
+
+    #[test]
+    fn empty_string_rejected() {
+        assert!(validate_daemon_url("").is_err());
+    }
+
+    #[test]
+    fn setting_roundtrip_in_memory() {
+        let db = crate::db::Database::open_memory().unwrap();
+
+        // Initially absent
+        assert!(db.get_setting("daemon_url").unwrap().is_none());
+
+        // Set and retrieve
+        db.set_setting("daemon_url", "ws://127.0.0.1:4200", "system")
+            .unwrap();
+        assert_eq!(
+            db.get_setting("daemon_url").unwrap().as_deref(),
+            Some("ws://127.0.0.1:4200")
+        );
+
+        // Update and check history
+        db.set_setting("daemon_url", "wss://new.example.com", "admin")
+            .unwrap();
+        assert_eq!(
+            db.get_setting("daemon_url").unwrap().as_deref(),
+            Some("wss://new.example.com")
+        );
+
+        let history = db.get_setting_history("daemon_url", 5).unwrap();
+        assert_eq!(history.len(), 2);
+        // Newest first
+        assert_eq!(history[0].new_value, "wss://new.example.com");
+        assert_eq!(history[0].old_value.as_deref(), Some("ws://127.0.0.1:4200"));
+        assert_eq!(history[0].changed_by, "admin");
+        assert_eq!(history[1].new_value, "ws://127.0.0.1:4200");
+        assert!(history[1].old_value.is_none());
+    }
+
+    #[test]
+    fn history_limit_respected() {
+        let db = crate::db::Database::open_memory().unwrap();
+
+        for i in 0..10 {
+            db.set_setting("daemon_url", &format!("ws://host:{}", 4200 + i), "system")
+                .unwrap();
+        }
+
+        let history = db.get_setting_history("daemon_url", 5).unwrap();
+        assert_eq!(history.len(), 5);
+    }
+
+    #[test]
+    fn history_for_unknown_key_is_empty() {
+        let db = crate::db::Database::open_memory().unwrap();
+        let history = db.get_setting_history("nonexistent_key", 10).unwrap();
+        assert!(history.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `app_settings` and `app_settings_history` SQLite tables via schema v2 migration
- Implements `GET /api/settings`, `PATCH /api/settings`, `GET /api/settings/history` endpoints
- Seeds `daemon_url` from config on first boot; preserves stored value on restart
- URL validation enforces `ws`/`wss`/`http`/`https` schemes
- WS broadcast on change is best-effort (logs the event; full reconnect wired in MH-027)
- 49 unit tests, all passing; clippy clean; rustfmt applied

## Test plan

- [ ] `cargo test -p hive-server` passes (49 tests)
- [ ] `GET /api/settings` returns `{"daemon_url":"..."}` with current stored value
- [ ] `PATCH /api/settings` with `{"daemon_url":"ws://new:4200"}` updates value, returns updated settings
- [ ] `PATCH /api/settings` with invalid URL returns 400
- [ ] `GET /api/settings/history` returns audit log entries newest-first
- [ ] After restart, stored `daemon_url` is preserved (not reset from config)

Closes tb-108 / MH-029.