### PR TITLE
fix(docker): switch hive-web base image to node:22 — tb-067

### DIFF
--- a/hive-web/Dockerfile
+++ b/hive-web/Dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage build for hive-web frontend
 # Uses pnpm for package management
 
-FROM node:22-slim AS base
+FROM node:22 AS base
 RUN npm install -g pnpm
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- Switches `hive-web/Dockerfile` base stage from `node:22-slim` to `node:22`
- `node:22-slim` omits `npm` (and `corepack`) on ARM platforms, causing `npm install -g pnpm` to fail at image build time
- The full `node:22` image ships `npm` on all architectures

## Why this matters

The `base` Dockerfile stage runs `RUN npm install -g pnpm`. Since `docker-compose.dev.yml` now uses `target: base` for hot-reload (merged in PR #122), any ARM developer or ARM CI runner would fail to build with:

```
/bin/sh: npm: not found
```

Switching to `node:22` (full image) resolves this on x86_64 and ARM alike.

## Test plan

- [x] One-file change — no logic modified
- [x] Frontend CI builds the Docker image as part of the React workflow
- [x] Existing Playwright smoke tests in `e2e/docker.spec.ts` cover the running container

Closes tb-067
