### PR TITLE
fix: add openssl deps to Dockerfile chef stage, make Cargo.lock writable in dev

### DIFF
--- a/crates/hive-server/Dockerfile
+++ b/crates/hive-server/Dockerfile
@@ -2,6 +2,7 @@
 # Uses cargo-chef for dependency caching
 
 FROM rust:1-slim AS chef
+RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
 RUN cargo install cargo-chef --locked
 WORKDIR /app
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,7 +24,7 @@ services:
     volumes:
       - ./crates:/app/crates
       - ./Cargo.toml:/app/Cargo.toml:ro
-      - ./Cargo.lock:/app/Cargo.lock:ro
+      - ./Cargo.lock:/app/Cargo.lock
       - cargo-cache:/usr/local/cargo/registry
       - hive-data:/root/.hive
     ports:


### PR DESCRIPTION
## Summary
- Adds `pkg-config` and `libssl-dev` to the Dockerfile `chef` stage so downstream stages (planner, builder) can compile crates that depend on OpenSSL
- Removes `:ro` from the `Cargo.lock` volume mount in `docker-compose.dev.yml` so Cargo can update the lockfile when dependencies change during development

## Test plan
- [ ] `docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build` succeeds
- [ ] Adding a new dependency in dev triggers a Cargo.lock update without mount errors