### PR TITLE
feat(hive-server): MH-029 app config — settings history, URL validation, audit log

### DIFF
--- a/crates/hive-server/src/db.rs
+++ b/crates/hive-server/src/db.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 use rusqlite::Connection;
 
 /// Schema version — bump when adding new migrations.
-const SCHEMA_VERSION: i64 = 3;
+const SCHEMA_VERSION: i64 = 4;
 
 /// SQL statements for schema v1.
 const SCHEMA_V1: &str = r#"
@@ -87,6 +87,29 @@ CREATE TABLE IF NOT EXISTS revoked_tokens (
 );
 "#;
 
+/// SQL statements for schema v4 — settings change history.
+const SCHEMA_V4: &str = r#"
+CREATE TABLE IF NOT EXISTS app_settings_history (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    key        TEXT NOT NULL,
+    old_value  TEXT,
+    new_value  TEXT NOT NULL,
+    changed_by TEXT NOT NULL DEFAULT 'system',
+    changed_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+"#;
+
+/// A row from `app_settings_history`.
+#[derive(Debug, Clone)]
+pub struct SettingHistoryRow {
+    pub id: i64,
+    pub key: String,
+    pub old_value: Option<String>,
+    pub new_value: String,
+    pub changed_by: String,
+    pub changed_at: String,
+}
+
 /// Thread-safe database handle.
 ///
 /// Uses a `Mutex<Connection>` for synchronous SQLite access from async
@@ -160,6 +183,12 @@ impl Database {
             tracing::info!("database migrated to schema v3");
         }
 
+        if current < 4 {
+            conn.execute_batch(SCHEMA_V4)?;
+            conn.execute("INSERT INTO _migrations (version) VALUES (4)", [])?;
+            tracing::info!("database migrated to schema v4");
+        }
+
         let final_version: i64 = conn.query_row(
             "SELECT COALESCE(MAX(version), 0) FROM _migrations",
             [],
@@ -179,6 +208,90 @@ impl Database {
     {
         let conn = self.conn.lock().expect("db lock poisoned");
         f(&conn)
+    }
+
+    /// Return the current value for `key`, or `None` if not set.
+    pub fn get_setting(&self, key: &str) -> Result<Option<String>, rusqlite::Error> {
+        self.with_conn(|conn| {
+            match conn.query_row(
+                "SELECT value FROM app_settings WHERE key = ?1",
+                [key],
+                |row| row.get(0),
+            ) {
+                Ok(v) => Ok(Some(v)),
+                Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+                Err(e) => Err(e),
+            }
+        })
+    }
+
+    /// Upsert a setting value, update `updated_by`, and record the change in
+    /// `app_settings_history`.
+    ///
+    /// `changed_by` should be a username or `"system"` for automatic changes.
+    pub fn set_setting(
+        &self,
+        key: &str,
+        value: &str,
+        changed_by: &str,
+    ) -> Result<(), rusqlite::Error> {
+        self.with_conn(|conn| {
+            let old_value: Option<String> = match conn.query_row(
+                "SELECT value FROM app_settings WHERE key = ?1",
+                [key],
+                |row| row.get(0),
+            ) {
+                Ok(v) => Some(v),
+                Err(rusqlite::Error::QueryReturnedNoRows) => None,
+                Err(e) => return Err(e),
+            };
+
+            conn.execute(
+                "INSERT INTO app_settings (key, value, updated_at, updated_by) \
+                 VALUES (?1, ?2, datetime('now'), ?3) \
+                 ON CONFLICT(key) DO UPDATE SET \
+                     value = excluded.value, \
+                     updated_at = excluded.updated_at, \
+                     updated_by = excluded.updated_by",
+                rusqlite::params![key, value, changed_by],
+            )?;
+
+            conn.execute(
+                "INSERT INTO app_settings_history (key, old_value, new_value, changed_by) \
+                 VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![key, old_value, value, changed_by],
+            )?;
+
+            Ok(())
+        })
+    }
+
+    /// Return the last `limit` history entries for `key`, newest first.
+    pub fn get_setting_history(
+        &self,
+        key: &str,
+        limit: i64,
+    ) -> Result<Vec<SettingHistoryRow>, rusqlite::Error> {
+        self.with_conn(|conn| {
+            let mut stmt = conn.prepare(
+                "SELECT id, key, old_value, new_value, changed_by, changed_at \
+                 FROM app_settings_history \
+                 WHERE key = ?1 \
+                 ORDER BY changed_at DESC, id DESC \
+                 LIMIT ?2",
+            )?;
+            let rows = stmt.query_map(rusqlite::params![key, limit], |row| {
+                Ok(SettingHistoryRow {
+                    id: row.get(0)?,
+                    key: row.get(1)?,
+                    old_value: row.get(2)?,
+                    new_value: row.get(3)?,
+                    changed_by: row.get(4)?,
+                    changed_at: row.get(5)?,
+                })
+            })?;
+            rows.collect()
+        })
     }
 }
 
@@ -201,6 +314,7 @@ mod tests {
             assert!(names.contains(&"api_keys".to_owned()));
             assert!(names.contains(&"team_manifests".to_owned()));
             assert!(names.contains(&"app_settings".to_owned()));
+            assert!(names.contains(&"app_settings_history".to_owned()));
             assert!(names.contains(&"local_users".to_owned()));
             assert!(names.contains(&"revoked_tokens".to_owned()));
             assert!(names.contains(&"_migrations".to_owned()));
@@ -371,5 +485,48 @@ mod tests {
             Ok(())
         })
         .unwrap();
+    }
+
+    #[test]
+    fn setting_set_and_get() {
+        let db = Database::open_memory().unwrap();
+        assert!(db.get_setting("daemon_url").unwrap().is_none());
+
+        db.set_setting("daemon_url", "ws://first:4200", "system")
+            .unwrap();
+        assert_eq!(
+            db.get_setting("daemon_url").unwrap().as_deref(),
+            Some("ws://first:4200")
+        );
+
+        db.set_setting("daemon_url", "ws://second:4200", "admin")
+            .unwrap();
+        assert_eq!(
+            db.get_setting("daemon_url").unwrap().as_deref(),
+            Some("ws://second:4200")
+        );
+
+        let history = db.get_setting_history("daemon_url", 10).unwrap();
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[0].new_value, "ws://second:4200");
+        assert_eq!(history[0].changed_by, "admin");
+    }
+
+    #[test]
+    fn setting_history_limit_respected() {
+        let db = Database::open_memory().unwrap();
+        for i in 0..10 {
+            db.set_setting("daemon_url", &format!("ws://host:{}", 4200 + i), "system")
+                .unwrap();
+        }
+        let history = db.get_setting_history("daemon_url", 5).unwrap();
+        assert_eq!(history.len(), 5);
+    }
+
+    #[test]
+    fn setting_history_unknown_key_empty() {
+        let db = Database::open_memory().unwrap();
+        let history = db.get_setting_history("nonexistent", 10).unwrap();
+        assert!(history.is_empty());
     }
 }

--- a/crates/hive-server/src/main.rs
+++ b/crates/hive-server/src/main.rs
@@ -133,6 +133,7 @@ async fn main() {
             "/api/settings",
             get(settings::get_settings).patch(settings::patch_settings),
         )
+        .route("/api/settings/history", get(settings::get_settings_history))
         .route("/ws/{room_id}", get(ws_relay::ws_handler))
         .layer(middleware::from_fn_with_state(
             Arc::clone(&state),

--- a/crates/hive-server/src/settings.rs
+++ b/crates/hive-server/src/settings.rs
@@ -1,24 +1,53 @@
 //! App settings API — runtime configuration stored in the database.
 //!
-//! Exposes `GET /api/settings` and `PATCH /api/settings` to read and update
-//! key/value settings. The `daemon_url` setting controls which room daemon
-//! all subsequent proxy calls target.
+//! Exposes `GET /api/settings`, `PATCH /api/settings`, and
+//! `GET /api/settings/history` to read, update, and audit key/value settings.
+//! The `daemon_url` setting controls which room daemon all proxy calls target.
 //!
 //! On first run, seeds defaults from environment variables (see [`seed_defaults`]).
+//!
+//! Every `PATCH` call is audited in `app_settings_history`. The `daemon_url`
+//! key is validated for URL scheme before writing — MH-029.
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use axum::extract::State;
+use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
+use crate::db::SettingHistoryRow;
 use crate::AppState;
 
 /// Known setting keys.
 pub const KEY_DAEMON_URL: &str = "daemon_url";
+
+/// Valid URL schemes for the daemon URL setting.
+const VALID_DAEMON_URL_SCHEMES: &[&str] = &["ws", "wss", "http", "https"];
+
+// ---------------------------------------------------------------------------
+// URL validation
+// ---------------------------------------------------------------------------
+
+/// Validate a daemon URL: must parse as a URL and use an accepted scheme.
+fn validate_daemon_url(raw: &str) -> Result<(), String> {
+    let parsed = reqwest::Url::parse(raw).map_err(|_| format!("invalid URL: {raw}"))?;
+
+    if !VALID_DAEMON_URL_SCHEMES.contains(&parsed.scheme()) {
+        return Err(format!(
+            "invalid scheme '{}': must be one of ws, wss, http, https",
+            parsed.scheme()
+        ));
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
 
 /// GET /api/settings — returns all settings as a JSON object.
 pub async fn get_settings(State(state): State<Arc<AppState>>) -> impl IntoResponse {
@@ -51,6 +80,10 @@ pub struct PatchSettingsRequest(HashMap<String, String>);
 ///
 /// Unknown keys are accepted (open key/value store). An empty patch body
 /// returns 400 — use explicit keys.
+///
+/// The `daemon_url` key is validated for URL scheme. Every write is audited in
+/// `app_settings_history`. The `changed_by` field is `"system"` until auth
+/// middleware provides user identity.
 pub async fn patch_settings(
     State(state): State<Arc<AppState>>,
     Json(PatchSettingsRequest(updates)): Json<PatchSettingsRequest>,
@@ -63,45 +96,117 @@ pub async fn patch_settings(
             .into_response();
     }
 
-    let result = state.db.with_conn(|conn| {
-        for (key, value) in &updates {
-            conn.execute(
-                "INSERT INTO app_settings (key, value, updated_at) \
-                 VALUES (?1, ?2, datetime('now')) \
-                 ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
-                rusqlite::params![key, value],
-            )?;
+    // Validate before writing anything.
+    if let Some(url) = updates.get(KEY_DAEMON_URL) {
+        if let Err(msg) = validate_daemon_url(url) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": msg})),
+            )
+                .into_response();
         }
-        Ok(())
+    }
+
+    // Write all keys with audit logging.
+    for (key, value) in &updates {
+        if let Err(e) = state.db.set_setting(key, value, "system") {
+            tracing::error!("failed to update setting '{key}': {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "internal error"})),
+            )
+                .into_response();
+        }
+        if key == KEY_DAEMON_URL {
+            tracing::info!(daemon_url = %value, "settings_changed: daemon_url updated");
+        }
+    }
+
+    // Return updated settings.
+    let settings_result = state.db.with_conn(|conn| {
+        let mut stmt = conn.prepare("SELECT key, value FROM app_settings ORDER BY key")?;
+        let pairs = stmt
+            .query_map([], |row| {
+                let k: String = row.get(0)?;
+                let v: String = row.get(1)?;
+                Ok((k, v))
+            })?
+            .collect::<Result<HashMap<String, String>, _>>()?;
+        Ok(pairs)
     });
 
-    match result {
-        Ok(()) => {
-            let settings_result = state.db.with_conn(|conn| {
-                let mut stmt = conn.prepare("SELECT key, value FROM app_settings ORDER BY key")?;
-                let pairs = stmt
-                    .query_map([], |row| {
-                        let k: String = row.get(0)?;
-                        let v: String = row.get(1)?;
-                        Ok((k, v))
-                    })?
-                    .collect::<Result<HashMap<String, String>, _>>()?;
-                Ok(pairs)
-            });
-            match settings_result {
-                Ok(settings) => (StatusCode::OK, Json(settings)).into_response(),
-                Err(e) => {
-                    tracing::error!("failed to read settings after patch: {e}");
-                    (StatusCode::INTERNAL_SERVER_ERROR, "internal error").into_response()
-                }
-            }
-        }
+    match settings_result {
+        Ok(settings) => (StatusCode::OK, Json(settings)).into_response(),
         Err(e) => {
-            tracing::error!("failed to update settings: {e}");
+            tracing::error!("failed to read settings after patch: {e}");
             (StatusCode::INTERNAL_SERVER_ERROR, "internal error").into_response()
         }
     }
 }
+
+/// Query parameters for `GET /api/settings/history`.
+#[derive(Debug, Deserialize)]
+pub struct HistoryQuery {
+    pub key: Option<String>,
+    pub limit: Option<i64>,
+}
+
+/// A single entry in the settings change log.
+#[derive(Debug, Serialize)]
+pub struct SettingHistoryItem {
+    pub id: i64,
+    pub key: String,
+    pub old_value: Option<String>,
+    pub new_value: String,
+    pub changed_by: String,
+    pub changed_at: String,
+}
+
+impl From<SettingHistoryRow> for SettingHistoryItem {
+    fn from(r: SettingHistoryRow) -> Self {
+        Self {
+            id: r.id,
+            key: r.key,
+            old_value: r.old_value,
+            new_value: r.new_value,
+            changed_by: r.changed_by,
+            changed_at: r.changed_at,
+        }
+    }
+}
+
+/// GET /api/settings/history — return the change log for a settings key.
+///
+/// Query params:
+/// - `key` (default: `daemon_url`)
+/// - `limit` (default: 5, max: 100)
+pub async fn get_settings_history(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<HistoryQuery>,
+) -> impl IntoResponse {
+    let key = params.key.unwrap_or_else(|| KEY_DAEMON_URL.to_owned());
+    let limit = params.limit.unwrap_or(5).clamp(1, 100);
+
+    let db = state.db.clone();
+    match tokio::task::spawn_blocking(move || db.get_setting_history(&key, limit)).await {
+        Ok(Ok(rows)) => {
+            let items: Vec<SettingHistoryItem> = rows.into_iter().map(Into::into).collect();
+            (StatusCode::OK, Json(items)).into_response()
+        }
+        Ok(Err(e)) => {
+            tracing::error!("failed to read settings history: {e}");
+            (StatusCode::INTERNAL_SERVER_ERROR, "internal error").into_response()
+        }
+        Err(e) => {
+            tracing::error!("spawn_blocking panicked: {e}");
+            (StatusCode::INTERNAL_SERVER_ERROR, "internal error").into_response()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Seed helpers
+// ---------------------------------------------------------------------------
 
 /// Seed default settings on first run.
 ///
@@ -126,6 +231,10 @@ pub fn seed_defaults(db: &crate::db::Database, daemon_url: &str) {
 pub fn resolve_daemon_url(config_ws_url: &str) -> String {
     std::env::var("HIVE_DAEMON_URL").unwrap_or_else(|_| config_ws_url.to_owned())
 }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
@@ -245,5 +354,38 @@ mod tests {
             let result = resolve_daemon_url("ws://config-value:4200");
             assert_eq!(result, "ws://config-value:4200");
         }
+    }
+
+    #[test]
+    fn valid_daemon_url_accepted() {
+        assert!(validate_daemon_url("ws://127.0.0.1:4200").is_ok());
+        assert!(validate_daemon_url("wss://daemon.example.com").is_ok());
+        assert!(validate_daemon_url("http://localhost:4200").is_ok());
+        assert!(validate_daemon_url("https://daemon.example.com/api").is_ok());
+    }
+
+    #[test]
+    fn invalid_daemon_url_rejected() {
+        assert!(validate_daemon_url("").is_err());
+        assert!(validate_daemon_url("localhost:4200").is_err());
+        assert!(validate_daemon_url("ftp://example.com").is_err());
+        assert!(validate_daemon_url("tcp://127.0.0.1:4200").is_err());
+    }
+
+    #[test]
+    fn set_setting_writes_audit_history() {
+        let db = test_db();
+        db.set_setting("daemon_url", "ws://first:4200", "system")
+            .unwrap();
+        db.set_setting("daemon_url", "ws://second:4200", "admin")
+            .unwrap();
+
+        let history = db.get_setting_history("daemon_url", 10).unwrap();
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[0].new_value, "ws://second:4200");
+        assert_eq!(history[0].old_value.as_deref(), Some("ws://first:4200"));
+        assert_eq!(history[0].changed_by, "admin");
+        assert_eq!(history[1].new_value, "ws://first:4200");
+        assert!(history[1].old_value.is_none());
     }
 }


### PR DESCRIPTION
## Summary

Builds on r2d2's MH-003 (settings store, schema v2) and saphire's MH-013 (JWT auth, schema v3) to add change history and validation for the daemon URL setting.

- **schema v4**: `app_settings_history` table — key, old_value, new_value, changed_by, changed_at
- **`Database.set_setting(key, value, changed_by)`** — upserts `app_settings` and writes a history row atomically
- **`Database.get_setting(key)`** — typed single-key read
- **`Database.get_setting_history(key, limit)`** — newest-first history with configurable limit
- **`PATCH /api/settings`** validates `daemon_url` URL scheme (ws/wss/http/https) before writing; all writes go through `set_setting()` for audit trail
- **`GET /api/settings/history`** — new endpoint, query params `key` (default: `daemon_url`) and `limit` (default 5, max 100)
- `changed_by` is `"system"` until user identity is available from auth middleware

Replaces #125 and #128 (rebased cleanly onto master v3 = JWT auth merged).

## Test plan

- [ ] `cargo test -p hive-server` passes (57 tests)
- [ ] `GET /api/settings` returns current settings (existing behaviour preserved)
- [ ] `PATCH /api/settings {"daemon_url":"ws://new:4200"}` updates value, returns all settings
- [ ] `PATCH /api/settings {"daemon_url":"ftp://bad"}` returns 400 with error message
- [ ] `GET /api/settings/history` returns audit log entries newest-first
- [ ] `GET /api/settings/history?key=daemon_url&limit=3` respects limit
- [ ] Restart: stored `daemon_url` preserved (seed_defaults is no-op if already set)
- [ ] schema v4 migration does not affect existing data in v1–v3 tables

Closes tb-108 / MH-029.