### PR TITLE
feat: MH-009 logout — POST /api/auth/logout + nav button

### DIFF
--- a/crates/hive-server/src/auth.rs
+++ b/crates/hive-server/src/auth.rs
@@ -168,6 +168,52 @@ pub(crate) async fn login(
 }
 
 // ---------------------------------------------------------------------------
+// Logout handler
+// ---------------------------------------------------------------------------
+
+/// Response body for a successful logout.
+#[derive(Serialize)]
+pub struct LogoutResponse {
+    pub message: &'static str,
+}
+
+/// `POST /api/auth/logout` — revoke the current JWT by adding its `jti` to
+/// `revoked_tokens`. The token remains cryptographically valid but will be
+/// rejected by `auth_middleware` on every subsequent request.
+///
+/// Always returns 200; the client must clear its local token regardless.
+pub(crate) async fn logout(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Extension(claims): axum::extract::Extension<Claims>,
+) -> Result<Json<LogoutResponse>, HiveError> {
+    // Store expires_at as "YYYY-MM-DD HH:MM:SS" (SQLite datetime format).
+    let expires_at_str = unix_secs_to_sqlite_datetime(claims.exp);
+
+    let db = state.db.clone();
+    let jti = claims.jti.clone();
+    let sub = claims.sub.clone();
+    tokio::task::spawn_blocking(move || {
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT OR IGNORE INTO revoked_tokens (jti, user_id, expires_at) \
+                 VALUES (?1, ?2, ?3)",
+                rusqlite::params![jti, sub, expires_at_str],
+            )?;
+            Ok::<_, rusqlite::Error>(())
+        })
+    })
+    .await
+    .map_err(|e| HiveError::Internal(format!("task join error: {e}")))?
+    .map_err(|e| HiveError::Internal(format!("db error: {e}")))?;
+
+    tracing::info!(jti = %claims.jti, username = %claims.username, "logout — token revoked");
+
+    Ok(Json(LogoutResponse {
+        message: "logged out",
+    }))
+}
+
+// ---------------------------------------------------------------------------
 // Token validation
 // ---------------------------------------------------------------------------
 
@@ -303,6 +349,39 @@ fn unix_now() -> u64 {
         .as_secs()
 }
 
+/// Format a Unix epoch (seconds) as "YYYY-MM-DD HH:MM:SS" for SQLite storage.
+fn unix_secs_to_sqlite_datetime(secs: u64) -> String {
+    // Manual ISO 8601 UTC formatting without external crates.
+    // Days since epoch → Gregorian calendar decomposition.
+    let total_secs = secs;
+    let s = total_secs % 60;
+    let total_mins = total_secs / 60;
+    let m = total_mins % 60;
+    let total_hours = total_mins / 60;
+    let h = total_hours % 24;
+    let days = total_hours / 24;
+
+    // Gregorian calendar calculation (valid for Unix epoch dates).
+    let (year, month, day) = days_to_ymd(days);
+    format!("{year:04}-{month:02}-{day:02} {h:02}:{m:02}:{s:02}")
+}
+
+/// Convert days-since-Unix-epoch to (year, month, day).
+fn days_to_ymd(days: u64) -> (u64, u64, u64) {
+    // Algorithm from https://howardhinnant.github.io/date_algorithms.html
+    let z = days + 719468;
+    let era = z / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -421,5 +500,96 @@ mod tests {
     fn valid_secret_is_accepted() {
         let ok = b"exactly-32-bytes-of-secret-key!!";
         assert!(ok.len() >= 32);
+    }
+
+    // -----------------------------------------------------------------------
+    // datetime helper tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn unix_epoch_formats_correctly() {
+        // Unix epoch 0 = 1970-01-01 00:00:00
+        assert_eq!(unix_secs_to_sqlite_datetime(0), "1970-01-01 00:00:00");
+    }
+
+    #[test]
+    fn known_timestamp_formats_correctly() {
+        // 2021-01-01 00:00:00 UTC = 1609459200
+        assert_eq!(
+            unix_secs_to_sqlite_datetime(1609459200),
+            "2021-01-01 00:00:00"
+        );
+    }
+
+    #[test]
+    fn leap_year_date_formats_correctly() {
+        // 2024-02-29 00:00:00 UTC (leap day) = 1709164800
+        assert_eq!(
+            unix_secs_to_sqlite_datetime(1709164800),
+            "2024-02-29 00:00:00"
+        );
+    }
+
+    #[test]
+    fn datetime_string_has_correct_length() {
+        let s = unix_secs_to_sqlite_datetime(unix_now());
+        assert_eq!(
+            s.len(),
+            19,
+            "expected 'YYYY-MM-DD HH:MM:SS' (19 chars), got: {s}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // revoked_tokens DB integration test
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn revoked_token_inserted_into_db() {
+        let db = crate::db::Database::open_memory().unwrap();
+        let jti = "test-jti-12345";
+        let expires_at = unix_secs_to_sqlite_datetime(unix_now() + 3600);
+
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO revoked_tokens (jti, user_id, expires_at) VALUES (?1, ?2, ?3)",
+                rusqlite::params![jti, "1", expires_at],
+            )?;
+            let count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM revoked_tokens WHERE jti = ?1",
+                [jti],
+                |row| row.get(0),
+            )?;
+            assert_eq!(count, 1);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn insert_or_ignore_duplicate_jti() {
+        let db = crate::db::Database::open_memory().unwrap();
+        let jti = "duplicate-jti";
+        let expires_at = unix_secs_to_sqlite_datetime(unix_now() + 3600);
+
+        db.with_conn(|conn| {
+            // Insert twice — second should be silently ignored.
+            conn.execute(
+                "INSERT OR IGNORE INTO revoked_tokens (jti, user_id, expires_at) VALUES (?1, ?2, ?3)",
+                rusqlite::params![jti, "1", expires_at],
+            )?;
+            conn.execute(
+                "INSERT OR IGNORE INTO revoked_tokens (jti, user_id, expires_at) VALUES (?1, ?2, ?3)",
+                rusqlite::params![jti, "1", expires_at],
+            )?;
+            let count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM revoked_tokens WHERE jti = ?1",
+                [jti],
+                |row| row.get(0),
+            )?;
+            assert_eq!(count, 1, "duplicate jti must not be inserted twice");
+            Ok(())
+        })
+        .unwrap();
     }
 }

--- a/crates/hive-server/src/main.rs
+++ b/crates/hive-server/src/main.rs
@@ -122,6 +122,7 @@ async fn main() {
 
     // Protected routes — require valid Bearer JWT.
     let protected_routes = Router::new()
+        .route("/api/auth/logout", post(auth::logout))
         .route("/api/rooms", get(rest_proxy::list_rooms))
         .route("/api/rooms/{room_id}", get(rest_proxy::get_room))
         .route(

--- a/hive-web/e2e/logout-mh009.spec.ts
+++ b/hive-web/e2e/logout-mh009.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * MH-009: Logout functionality
+ *
+ * Tests that the logout flow correctly:
+ * - Calls POST /api/auth/logout and receives 200
+ * - Revokes the token (subsequent requests return 401)
+ * - Clears local auth state
+ * - Redirects to /login
+ *
+ * Requires the server running with HIVE_JWT_SECRET + HIVE_ADMIN_USER/PASSWORD.
+ */
+
+import { test, expect } from '@playwright/test';
+
+const API_URL = process.env.HIVE_API_URL || 'http://localhost:3000';
+const ADMIN_USER = process.env.HIVE_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.HIVE_ADMIN_PASSWORD || 'test-password';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function loginAsAdmin(
+  request: Parameters<typeof test>[1] extends { request: infer R } ? R : never,
+): Promise<string> {
+  const res = await request.post(`${API_URL}/api/auth/login`, {
+    data: { username: ADMIN_USER, password: ADMIN_PASSWORD },
+  });
+  expect(res.status()).toBe(200);
+  const { token } = await res.json();
+  expect(typeof token).toBe('string');
+  return token as string;
+}
+
+// ---------------------------------------------------------------------------
+// AC-2: POST /api/auth/logout returns 200 with a valid token
+// ---------------------------------------------------------------------------
+
+test.describe('MH-009: POST /api/auth/logout — success', () => {
+  test('returns 200 with {message} on valid Bearer token', async ({ request }) => {
+    const token = await loginAsAdmin({ request });
+    const res = await request.post(`${API_URL}/api/auth/logout`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(typeof body.message).toBe('string');
+    expect(body.message.length).toBeGreaterThan(0);
+  });
+
+  test('token is revoked after logout — protected endpoint returns 401', async ({ request }) => {
+    const token = await loginAsAdmin({ request });
+
+    // Confirm access before logout.
+    const before = await request.get(`${API_URL}/api/rooms`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(before.status()).not.toBe(401);
+
+    // Logout.
+    await request.post(`${API_URL}/api/auth/logout`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    // The same token must now be rejected.
+    const after = await request.get(`${API_URL}/api/rooms`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(after.status()).toBe(401);
+    const body = await after.json();
+    expect(body.code).toBe('UNAUTHORIZED');
+  });
+
+  test('double-logout with same token is idempotent — returns 401 on second call', async ({ request }) => {
+    const token = await loginAsAdmin({ request });
+
+    await request.post(`${API_URL}/api/auth/logout`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    // Second logout with revoked token → auth_middleware rejects it.
+    const res = await request.post(`${API_URL}/api/auth/logout`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status()).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC: missing / invalid token on logout endpoint
+// ---------------------------------------------------------------------------
+
+test.describe('MH-009: POST /api/auth/logout — auth required', () => {
+  test('missing token returns 401', async ({ request }) => {
+    const res = await request.post(`${API_URL}/api/auth/logout`);
+    expect(res.status()).toBe(401);
+    const body = await res.json();
+    expect(body.code).toBe('UNAUTHORIZED');
+  });
+
+  test('invalid token returns 401', async ({ request }) => {
+    const res = await request.post(`${API_URL}/api/auth/logout`, {
+      headers: { Authorization: 'Bearer garbage.token.value' },
+    });
+    expect(res.status()).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC: UI — logout button clears token and redirects (browser tests)
+// ---------------------------------------------------------------------------
+
+test.describe('MH-009: logout UI', () => {
+  test.beforeEach(async ({ page, request }) => {
+    // Seed localStorage with a valid token before navigating to the app.
+    const token = await loginAsAdmin({ request });
+    await page.goto(`${process.env.HIVE_WEB_URL || 'http://localhost:5173'}/`);
+    await page.evaluate((t) => localStorage.setItem('hive-auth-token', t), token);
+    await page.reload();
+  });
+
+  test('logout button is visible in the top nav', async ({ page }) => {
+    await expect(page.getByTestId('logout-button')).toBeVisible();
+  });
+
+  test('clicking logout redirects to /login', async ({ page }) => {
+    await page.getByTestId('logout-button').click();
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test('local storage token is cleared after logout', async ({ page }) => {
+    await page.getByTestId('logout-button').click();
+    await page.waitForURL(/\/login/);
+    const token = await page.evaluate(() => localStorage.getItem('hive-auth-token'));
+    expect(token).toBeNull();
+  });
+
+  test('navigating to protected route after logout redirects to /login', async ({ page }) => {
+    await page.getByTestId('logout-button').click();
+    await page.waitForURL(/\/login/);
+    await page.goto(`${process.env.HIVE_WEB_URL || 'http://localhost:5173'}/rooms`);
+    await expect(page).toHaveURL(/\/login/);
+  });
+});

--- a/hive-web/src/App.tsx
+++ b/hive-web/src/App.tsx
@@ -10,6 +10,7 @@ import { useWebSocket } from "./hooks/useWebSocket";
 import type { ConnectionStatus } from "./hooks/useWebSocket";
 import type { Room } from "./components/RoomList";
 import type { Member } from "./components/MemberPanel";
+import { authHeader, clearToken } from "./lib/auth";
 
 type Tab = "rooms" | "agents" | "tasks" | "costs";
 const TABS: Tab[] = ["rooms", "agents", "tasks", "costs"];
@@ -48,6 +49,23 @@ function App() {
 
   const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
   const [rooms, setRooms] = useState<Room[]>([]);
+  const [loggingOut, setLoggingOut] = useState(false);
+
+  /** Invalidate the server-side token and clear local auth state. */
+  const handleLogout = useCallback(async () => {
+    setLoggingOut(true);
+    try {
+      await fetch(`${API_BASE}/api/auth/logout`, {
+        method: "POST",
+        headers: authHeader(),
+      });
+    } catch {
+      // Ignore — local state is always cleared regardless.
+    } finally {
+      clearToken();
+      navigate("/login", { replace: true });
+    }
+  }, [navigate]);
 
   // WebSocket connection to the selected room
   const wsUrl = selectedRoomId ? `${WS_BASE}/ws/${selectedRoomId}` : "";
@@ -165,8 +183,17 @@ function App() {
             {tab}
           </button>
         ))}
-        <div className="ml-auto">
+        <div className="ml-auto flex items-center gap-3">
           <StatusDot status={status} />
+          <button
+            onClick={handleLogout}
+            disabled={loggingOut}
+            data-testid="logout-button"
+            className="px-3 py-1 rounded text-sm text-gray-400 hover:text-gray-200 hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            aria-label="Log out"
+          >
+            {loggingOut ? "Logging out…" : "Log out"}
+          </button>
         </div>
       </nav>
 


### PR DESCRIPTION
## Summary

- Adds `POST /api/auth/logout` (protected route): extracts `jti` from Bearer token claims, inserts into `revoked_tokens` table — token is immediately rejected by `auth_middleware` on all subsequent requests
- Adds **Log out** button to the top nav in `App.tsx`; calls `clearToken()` regardless of server response to ensure client state is always cleared
- Redirects to `/login` after logout
- Button shows "Logging out…" while the request is in flight (AC: visual feedback)
- Existing `RequireAuth` guard handles browser back-button protection

## Acceptance criteria covered (MH-009)

- Logout accessible from main navigation (Log out button in nav)
- `POST /api/auth/logout` invalidates the server-side token via `jti` revocation
- Local token cleared regardless of server result
- Redirect to `/login` after logout
- Browser back → protected route → redirected to `/login` (via existing RequireAuth)
- Brief "Logging out…" feedback during request
- Failed API call still clears local state (try/catch in handler)

## Test plan

- [ ] 57 Rust unit tests pass (`cargo test -p hive-server`)
- [ ] Clippy clean, `cargo fmt --check` clean
- [ ] Playwright API tests: `hive-web/e2e/logout-mh009.spec.ts` — login → logout → token revoked (401), double-logout idempotent, auth required on logout endpoint
- [ ] Playwright UI tests: logout button visible, click → `/login`, localStorage cleared, back-nav → `/login`