### PR TITLE
feat(MH-012): admin user management — CRUD API + UsersPage

### DIFF
--- a/crates/hive-server/src/admin.rs
+++ b/crates/hive-server/src/admin.rs
@@ -1,0 +1,594 @@
+//! Admin user management API (MH-012).
+//!
+//! All routes require a valid Bearer JWT **and** `role = "admin"`.
+//! Non-admin requests are rejected with HTTP 403.
+//!
+//! Routes (all under `/api/admin/users`):
+//! - `GET  /api/admin/users`          — list users (paginated)
+//! - `POST /api/admin/users`          — create a new user
+//! - `PATCH /api/admin/users/:id`     — update role or active status
+//! - `DELETE /api/admin/users/:id`    — hard-delete a user (with last-admin guard)
+
+use axum::extract::{Path, Query, State};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::auth::Claims;
+use crate::error::{HiveError, HiveResult};
+use crate::AppState;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// A user record returned by the admin list / create endpoints.
+#[derive(Debug, Serialize)]
+pub struct AdminUser {
+    pub id: i64,
+    pub username: String,
+    pub role: String,
+    pub active: bool,
+    pub created_at: String,
+}
+
+/// Query parameters for `GET /api/admin/users`.
+#[derive(Debug, Deserialize)]
+pub struct ListUsersQuery {
+    /// Page number (1-based). Defaults to 1.
+    #[serde(default = "default_page")]
+    pub page: u32,
+    /// Page size. Defaults to 50, capped at 200.
+    #[serde(default = "default_page_size")]
+    pub page_size: u32,
+}
+
+fn default_page() -> u32 {
+    1
+}
+fn default_page_size() -> u32 {
+    50
+}
+
+/// Response for `GET /api/admin/users`.
+#[derive(Serialize)]
+pub struct ListUsersResponse {
+    pub users: Vec<AdminUser>,
+    pub total: i64,
+    pub page: u32,
+    pub page_size: u32,
+}
+
+/// Request body for `POST /api/admin/users`.
+#[derive(Deserialize)]
+pub struct CreateUserRequest {
+    pub username: String,
+    pub password: String,
+    /// Role to assign. Defaults to "user" if omitted.
+    #[serde(default = "default_role")]
+    pub role: String,
+}
+
+fn default_role() -> String {
+    "user".to_string()
+}
+
+/// Request body for `PATCH /api/admin/users/:id`.
+#[derive(Deserialize)]
+pub struct PatchUserRequest {
+    /// New role. Must be one of "admin", "user".
+    pub role: Option<String>,
+    /// Active status.
+    pub active: Option<bool>,
+}
+
+/// Response for `POST /api/admin/users`.
+#[derive(Serialize)]
+pub struct CreateUserResponse {
+    pub id: i64,
+    pub username: String,
+    pub role: String,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Verify the caller has role = "admin". Returns 403 otherwise.
+fn require_admin(claims: &Claims) -> HiveResult<()> {
+    if claims.role != "admin" {
+        return Err(HiveError::Forbidden("admin role required".into()));
+    }
+    Ok(())
+}
+
+/// Validate that a role string is one of the accepted values.
+fn validate_role(role: &str) -> HiveResult<()> {
+    match role {
+        "admin" | "user" => Ok(()),
+        _ => Err(HiveError::BadRequest(format!(
+            "invalid role '{role}'; must be 'admin' or 'user'"
+        ))),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// `GET /api/admin/users` — list all users, paginated.
+pub(crate) async fn list_users(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Extension(claims): axum::extract::Extension<Claims>,
+    Query(params): Query<ListUsersQuery>,
+) -> HiveResult<Json<ListUsersResponse>> {
+    require_admin(&claims)?;
+
+    let page = params.page.max(1);
+    let page_size = params.page_size.clamp(1, 200);
+    let offset = (page - 1) * page_size;
+
+    let db = state.db.clone();
+    tokio::task::spawn_blocking(move || {
+        db.with_conn(|conn| {
+            let total: i64 =
+                conn.query_row("SELECT COUNT(*) FROM local_users", [], |row| row.get(0))?;
+
+            let mut stmt = conn.prepare(
+                "SELECT id, username, role, active, created_at \
+                 FROM local_users \
+                 ORDER BY id \
+                 LIMIT ?1 OFFSET ?2",
+            )?;
+
+            let users: Vec<AdminUser> = stmt
+                .query_map([page_size as i64, offset as i64], |row| {
+                    Ok(AdminUser {
+                        id: row.get(0)?,
+                        username: row.get(1)?,
+                        role: row.get(2)?,
+                        active: row.get::<_, i64>(3)? != 0,
+                        created_at: row.get(4)?,
+                    })
+                })?
+                .collect::<Result<Vec<_>, _>>()?;
+
+            Ok(ListUsersResponse {
+                users,
+                total,
+                page,
+                page_size,
+            })
+        })
+    })
+    .await
+    .map_err(|e| HiveError::Internal(format!("task join error: {e}")))?
+    .map_err(|e| HiveError::Internal(format!("db error: {e}")))
+    .map(Json)
+}
+
+/// `POST /api/admin/users` — create a new local user.
+pub(crate) async fn create_user(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Extension(claims): axum::extract::Extension<Claims>,
+    Json(req): Json<CreateUserRequest>,
+) -> HiveResult<Json<CreateUserResponse>> {
+    require_admin(&claims)?;
+
+    if req.username.is_empty() || req.password.is_empty() {
+        return Err(HiveError::BadRequest(
+            "username and password are required".into(),
+        ));
+    }
+    validate_role(&req.role)?;
+
+    let password = req.password.clone();
+    let hash = tokio::task::spawn_blocking(move || bcrypt::hash(&password, bcrypt::DEFAULT_COST))
+        .await
+        .map_err(|e| HiveError::Internal(format!("task join error: {e}")))?
+        .map_err(|e| HiveError::Internal(format!("bcrypt error: {e}")))?;
+
+    let db = state.db.clone();
+    let username = req.username.clone();
+    let role = req.role.clone();
+    tokio::task::spawn_blocking(move || {
+        db.with_conn(|conn| {
+            let result = conn.execute(
+                "INSERT INTO local_users (username, password_hash, role) VALUES (?1, ?2, ?3)",
+                rusqlite::params![username, hash, role],
+            );
+            match result {
+                Err(rusqlite::Error::SqliteFailure(e, _))
+                    if e.code == rusqlite::ErrorCode::ConstraintViolation =>
+                {
+                    return Err(rusqlite::Error::SqliteFailure(
+                        e,
+                        Some("username already exists".to_string()),
+                    ))
+                }
+                Err(e) => return Err(e),
+                Ok(_) => {}
+            }
+            let id: i64 = conn.query_row("SELECT last_insert_rowid()", [], |row| row.get(0))?;
+            Ok(CreateUserResponse {
+                id,
+                username: req.username,
+                role: req.role,
+            })
+        })
+    })
+    .await
+    .map_err(|e| HiveError::Internal(format!("task join error: {e}")))?
+    .map_err(|e| {
+        if e.to_string().contains("username already exists")
+            || e.to_string().contains("UNIQUE constraint")
+        {
+            HiveError::Conflict("username already exists".into())
+        } else {
+            HiveError::Internal(format!("db error: {e}"))
+        }
+    })
+    .map(Json)
+}
+
+/// `PATCH /api/admin/users/:id` — update role or active status.
+///
+/// Guards against removing the last admin: if the caller tries to change their
+/// own role away from "admin" and no other admin exists, this returns 409.
+pub(crate) async fn patch_user(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Extension(claims): axum::extract::Extension<Claims>,
+    Path(user_id): Path<i64>,
+    Json(req): Json<PatchUserRequest>,
+) -> HiveResult<Json<AdminUser>> {
+    require_admin(&claims)?;
+
+    if let Some(ref role) = req.role {
+        validate_role(role)?;
+    }
+
+    let db = state.db.clone();
+    let caller_sub = claims.sub.clone();
+    tokio::task::spawn_blocking(move || {
+        db.with_conn(|conn| {
+            // Verify target user exists.
+            let existing: Option<(String, i64)> = conn
+                .query_row(
+                    "SELECT role, active FROM local_users WHERE id = ?1",
+                    [user_id],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .ok();
+            let (current_role, current_active) =
+                existing.ok_or_else(|| rusqlite::Error::QueryReturnedNoRows)?;
+
+            let new_role = req.role.as_deref().unwrap_or(&current_role);
+            let new_active = req.active.map(|b| b as i64).unwrap_or(current_active);
+
+            // Last-admin guard: if changing this user's role away from admin,
+            // make sure at least one other admin remains.
+            if current_role == "admin" && new_role != "admin" {
+                let admin_count: i64 = conn.query_row(
+                    "SELECT COUNT(*) FROM local_users WHERE role = 'admin' AND active = 1",
+                    [],
+                    |row| row.get(0),
+                )?;
+                if admin_count <= 1 {
+                    // Use a unique error string we can detect below.
+                    return Err(rusqlite::Error::SqliteFailure(
+                        rusqlite::ffi::Error {
+                            code: rusqlite::ErrorCode::ConstraintViolation,
+                            extended_code: 0,
+                        },
+                        Some("LAST_ADMIN".to_string()),
+                    ));
+                }
+            }
+
+            conn.execute(
+                "UPDATE local_users SET role = ?1, active = ?2 WHERE id = ?3",
+                rusqlite::params![new_role, new_active, user_id],
+            )?;
+
+            let user = conn.query_row(
+                "SELECT id, username, role, active, created_at FROM local_users WHERE id = ?1",
+                [user_id],
+                |row| {
+                    Ok(AdminUser {
+                        id: row.get(0)?,
+                        username: row.get(1)?,
+                        role: row.get(2)?,
+                        active: row.get::<_, i64>(3)? != 0,
+                        created_at: row.get(4)?,
+                    })
+                },
+            )?;
+
+            let _ = caller_sub; // suppress unused warning
+            Ok(user)
+        })
+    })
+    .await
+    .map_err(|e| HiveError::Internal(format!("task join error: {e}")))?
+    .map_err(|e| {
+        let s = e.to_string();
+        if s.contains("LAST_ADMIN") {
+            HiveError::Conflict("cannot remove admin role: this is the last active admin".into())
+        } else if matches!(e, rusqlite::Error::QueryReturnedNoRows) {
+            HiveError::NotFound(format!("user {user_id} not found"))
+        } else {
+            HiveError::Internal(format!("db error: {e}"))
+        }
+    })
+    .map(Json)
+}
+
+/// `DELETE /api/admin/users/:id` — hard-delete a user.
+///
+/// Requires the caller to be admin. The caller cannot delete themselves.
+/// The last active admin cannot be deleted.
+pub(crate) async fn delete_user(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Extension(claims): axum::extract::Extension<Claims>,
+    Path(user_id): Path<i64>,
+) -> HiveResult<axum::http::StatusCode> {
+    require_admin(&claims)?;
+
+    // Prevent self-deletion.
+    if claims.sub == user_id.to_string() {
+        return Err(HiveError::Conflict("cannot delete your own account".into()));
+    }
+
+    let db = state.db.clone();
+    tokio::task::spawn_blocking(move || {
+        db.with_conn(|conn| {
+            // Check user exists and get their role.
+            let (role, _active): (String, i64) = conn
+                .query_row(
+                    "SELECT role, active FROM local_users WHERE id = ?1",
+                    [user_id],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .map_err(|_| rusqlite::Error::QueryReturnedNoRows)?;
+
+            // Last-admin guard.
+            if role == "admin" {
+                let admin_count: i64 = conn.query_row(
+                    "SELECT COUNT(*) FROM local_users WHERE role = 'admin' AND active = 1",
+                    [],
+                    |row| row.get(0),
+                )?;
+                if admin_count <= 1 {
+                    return Err(rusqlite::Error::SqliteFailure(
+                        rusqlite::ffi::Error {
+                            code: rusqlite::ErrorCode::ConstraintViolation,
+                            extended_code: 0,
+                        },
+                        Some("LAST_ADMIN".to_string()),
+                    ));
+                }
+            }
+
+            conn.execute("DELETE FROM local_users WHERE id = ?1", [user_id])?;
+            Ok(())
+        })
+    })
+    .await
+    .map_err(|e| HiveError::Internal(format!("task join error: {e}")))?
+    .map_err(|e| {
+        let s = e.to_string();
+        if s.contains("LAST_ADMIN") {
+            HiveError::Conflict("cannot delete the last active admin".into())
+        } else if matches!(e, rusqlite::Error::QueryReturnedNoRows) {
+            HiveError::NotFound(format!("user {user_id} not found"))
+        } else {
+            HiveError::Internal(format!("db error: {e}"))
+        }
+    })?;
+
+    Ok(axum::http::StatusCode::NO_CONTENT)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+
+    fn seed_admin(db: &Database) -> i64 {
+        let hash = bcrypt::hash("admin-pass", 4).unwrap();
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO local_users (username, password_hash, role) VALUES ('admin', ?1, 'admin')",
+                [&hash],
+            )?;
+            Ok(conn.last_insert_rowid())
+        })
+        .unwrap()
+    }
+
+    fn seed_user(db: &Database, username: &str) -> i64 {
+        let hash = bcrypt::hash("pass", 4).unwrap();
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO local_users (username, password_hash, role) VALUES (?1, ?2, 'user')",
+                rusqlite::params![username, hash],
+            )?;
+            Ok(conn.last_insert_rowid())
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn require_admin_passes_for_admin_role() {
+        let claims = Claims {
+            sub: "1".into(),
+            username: "admin".into(),
+            role: "admin".into(),
+            jti: "jti".into(),
+            iat: 0,
+            exp: u64::MAX,
+        };
+        assert!(require_admin(&claims).is_ok());
+    }
+
+    #[test]
+    fn require_admin_fails_for_user_role() {
+        let claims = Claims {
+            sub: "2".into(),
+            username: "user".into(),
+            role: "user".into(),
+            jti: "jti".into(),
+            iat: 0,
+            exp: u64::MAX,
+        };
+        let err = require_admin(&claims).unwrap_err();
+        assert!(matches!(err, HiveError::Forbidden(_)));
+    }
+
+    #[test]
+    fn validate_role_accepts_valid_roles() {
+        assert!(validate_role("admin").is_ok());
+        assert!(validate_role("user").is_ok());
+    }
+
+    #[test]
+    fn validate_role_rejects_invalid_role() {
+        let err = validate_role("superuser").unwrap_err();
+        assert!(matches!(err, HiveError::BadRequest(_)));
+    }
+
+    #[test]
+    fn list_users_db_query_returns_all_users() {
+        let db = Database::open_memory().unwrap();
+        seed_admin(&db);
+        seed_user(&db, "alice");
+        seed_user(&db, "bob");
+
+        let result = db
+            .with_conn(|conn| {
+                let total: i64 =
+                    conn.query_row("SELECT COUNT(*) FROM local_users", [], |row| row.get(0))?;
+                Ok(total)
+            })
+            .unwrap();
+
+        assert_eq!(result, 3);
+    }
+
+    #[test]
+    fn active_column_defaults_to_one() {
+        let db = Database::open_memory().unwrap();
+        let id = seed_user(&db, "newuser");
+
+        db.with_conn(|conn| {
+            let active: i64 = conn.query_row(
+                "SELECT active FROM local_users WHERE id = ?1",
+                [id],
+                |row| row.get(0),
+            )?;
+            assert_eq!(active, 1);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn deactivate_user_sets_active_to_zero() {
+        let db = Database::open_memory().unwrap();
+        let id = seed_user(&db, "victim");
+
+        db.with_conn(|conn| {
+            conn.execute("UPDATE local_users SET active = 0 WHERE id = ?1", [id])?;
+            let active: i64 = conn.query_row(
+                "SELECT active FROM local_users WHERE id = ?1",
+                [id],
+                |row| row.get(0),
+            )?;
+            assert_eq!(active, 0);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn last_admin_guard_prevents_role_downgrade() {
+        let db = Database::open_memory().unwrap();
+        let admin_id = seed_admin(&db);
+
+        // There is only one admin. Trying to set role to 'user' must fail.
+        let result = db.with_conn(|conn| {
+            let admin_count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM local_users WHERE role = 'admin' AND active = 1",
+                [],
+                |row| row.get(0),
+            )?;
+            if admin_count <= 1 {
+                return Err(rusqlite::Error::SqliteFailure(
+                    rusqlite::ffi::Error {
+                        code: rusqlite::ErrorCode::ConstraintViolation,
+                        extended_code: 0,
+                    },
+                    Some("LAST_ADMIN".to_string()),
+                ));
+            }
+            conn.execute(
+                "UPDATE local_users SET role = 'user' WHERE id = ?1",
+                [admin_id],
+            )?;
+            Ok(())
+        });
+        assert!(result.is_err());
+        let s = result.unwrap_err().to_string();
+        assert!(
+            s.contains("LAST_ADMIN"),
+            "expected LAST_ADMIN guard, got: {s}"
+        );
+    }
+
+    #[test]
+    fn delete_non_last_admin_succeeds() {
+        let db = Database::open_memory().unwrap();
+        seed_admin(&db);
+        // Add second admin
+        let hash = bcrypt::hash("pass2", 4).unwrap();
+        let id2 = db
+            .with_conn(|conn| {
+                conn.execute(
+                    "INSERT INTO local_users (username, password_hash, role) VALUES ('admin2', ?1, 'admin')",
+                    [&hash],
+                )?;
+                Ok(conn.last_insert_rowid())
+            })
+            .unwrap();
+
+        db.with_conn(|conn| {
+            conn.execute("DELETE FROM local_users WHERE id = ?1", [id2])?;
+            let count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM local_users WHERE id = ?1",
+                [id2],
+                |row| row.get(0),
+            )?;
+            assert_eq!(count, 0);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn username_uniqueness_enforced() {
+        let db = Database::open_memory().unwrap();
+        seed_user(&db, "dupeuser");
+        let result = db.with_conn(|conn| {
+            let hash = bcrypt::hash("pass", 4).unwrap();
+            conn.execute(
+                "INSERT INTO local_users (username, password_hash, role) VALUES ('dupeuser', ?1, 'user')",
+                [&hash],
+            )
+        });
+        assert!(result.is_err());
+    }
+}

--- a/crates/hive-server/src/auth.rs
+++ b/crates/hive-server/src/auth.rs
@@ -115,18 +115,27 @@ pub(crate) async fn login(
 
     let (user_id, role) = tokio::task::spawn_blocking(move || {
         db.with_conn(|conn| {
-            let result: Option<(i64, String, String)> = conn
+            // Include active column — deactivated users must not log in.
+            let result: Option<(i64, String, String, i64)> = conn
                 .query_row(
-                    "SELECT id, password_hash, role FROM local_users WHERE username = ?1",
+                    "SELECT id, password_hash, role, active \
+                     FROM local_users WHERE username = ?1",
                     [&username],
-                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
                 )
                 .ok();
 
             match result {
                 None => Err(rusqlite::Error::QueryReturnedNoRows),
-                Some((id, hash, role)) => match bcrypt::verify(&password, &hash) {
-                    Ok(true) => Ok((id, role)),
+                Some((id, hash, role, active)) => match bcrypt::verify(&password, &hash) {
+                    Ok(true) if active != 0 => Ok((id, role)),
+                    Ok(true) => Err(rusqlite::Error::SqliteFailure(
+                        rusqlite::ffi::Error {
+                            code: rusqlite::ErrorCode::ConstraintViolation,
+                            extended_code: 0,
+                        },
+                        Some("ACCOUNT_DISABLED".to_string()),
+                    )),
                     _ => Err(rusqlite::Error::QueryReturnedNoRows),
                 },
             }
@@ -134,7 +143,13 @@ pub(crate) async fn login(
     })
     .await
     .map_err(|e| HiveError::Internal(format!("task join error: {e}")))?
-    .map_err(|_| HiveError::Unauthorized("invalid username or password".into()))?;
+    .map_err(|e| {
+        if e.to_string().contains("ACCOUNT_DISABLED") {
+            HiveError::Forbidden("account is disabled".into())
+        } else {
+            HiveError::Unauthorized("invalid username or password".into())
+        }
+    })?;
 
     // Issue JWT.
     let now = unix_now();

--- a/crates/hive-server/src/db.rs
+++ b/crates/hive-server/src/db.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 use rusqlite::Connection;
 
 /// Schema version — bump when adding new migrations.
-const SCHEMA_VERSION: i64 = 4;
+const SCHEMA_VERSION: i64 = 5;
 
 /// SQL statements for schema v1.
 const SCHEMA_V1: &str = r#"
@@ -97,6 +97,11 @@ CREATE TABLE IF NOT EXISTS app_settings_history (
     changed_by TEXT NOT NULL DEFAULT 'system',
     changed_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
+"#;
+
+/// SQL statements for schema v5 — user management fields.
+const SCHEMA_V5: &str = r#"
+ALTER TABLE local_users ADD COLUMN active INTEGER NOT NULL DEFAULT 1;
 "#;
 
 /// A row from `app_settings_history`.
@@ -187,6 +192,12 @@ impl Database {
             conn.execute_batch(SCHEMA_V4)?;
             conn.execute("INSERT INTO _migrations (version) VALUES (4)", [])?;
             tracing::info!("database migrated to schema v4");
+        }
+
+        if current < 5 {
+            conn.execute_batch(SCHEMA_V5)?;
+            conn.execute("INSERT INTO _migrations (version) VALUES (5)", [])?;
+            tracing::info!("database migrated to schema v5");
         }
 
         let final_version: i64 = conn.query_row(

--- a/crates/hive-server/src/main.rs
+++ b/crates/hive-server/src/main.rs
@@ -1,3 +1,4 @@
+pub mod admin;
 pub mod auth;
 mod config;
 pub mod daemon;
@@ -127,6 +128,14 @@ async fn main() {
         .route("/api/auth/me", get(auth::me))
         .route("/api/users/me", get(users::me))
         .route("/api/auth/logout", post(auth::logout))
+        .route(
+            "/api/admin/users",
+            get(admin::list_users).post(admin::create_user),
+        )
+        .route(
+            "/api/admin/users/{id}",
+            axum::routing::patch(admin::patch_user).delete(admin::delete_user),
+        )
         .route(
             "/api/rooms",
             get(rooms::list_rooms).post(rooms::create_room),

--- a/hive-web/e2e/user-mgmt-mh012.spec.ts
+++ b/hive-web/e2e/user-mgmt-mh012.spec.ts
@@ -1,0 +1,439 @@
+/**
+ * MH-012: User management (admin only)
+ *
+ * Tests the full admin user-management API:
+ *   GET    /api/admin/users         — list with pagination
+ *   POST   /api/admin/users         — create user
+ *   PATCH  /api/admin/users/:id     — update role / active status
+ *   DELETE /api/admin/users/:id     — delete user
+ *
+ * Requires the server running with:
+ *   HIVE_JWT_SECRET=<>=32-byte secret>
+ *   HIVE_ADMIN_USER=admin
+ *   HIVE_ADMIN_PASSWORD=test-password
+ */
+
+import { test, expect } from '@playwright/test';
+
+const API_URL = process.env.HIVE_API_URL || 'http://localhost:3000';
+const ADMIN_USER = process.env.HIVE_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.HIVE_ADMIN_PASSWORD || 'test-password';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type APIRequest = Parameters<typeof test>[1] extends { request: infer R } ? R : never;
+
+async function loginAs(request: APIRequest, username: string, password: string): Promise<string> {
+  const res = await request.post(`${API_URL}/api/auth/login`, {
+    data: { username, password },
+  });
+  expect(res.status()).toBe(200);
+  const { token } = await res.json();
+  return token as string;
+}
+
+async function loginAsAdmin(request: APIRequest): Promise<string> {
+  return loginAs(request, ADMIN_USER, ADMIN_PASSWORD);
+}
+
+/** Create a user via the admin API and return its id. Cleans up after the test. */
+async function createTestUser(
+  request: APIRequest,
+  token: string,
+  username: string,
+  role: 'user' | 'admin' = 'user',
+): Promise<number> {
+  const res = await request.post(`${API_URL}/api/admin/users`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { username, password: 'TestPass1!', role },
+  });
+  expect(res.status()).toBe(201);
+  const body = await res.json();
+  return body.id as number;
+}
+
+async function deleteUser(request: APIRequest, token: string, userId: number): Promise<void> {
+  await request.delete(`${API_URL}/api/admin/users/${userId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+// Unique suffix to avoid collisions across parallel runs.
+const uid = () => `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+
+// ---------------------------------------------------------------------------
+// AC-1: GET /api/admin/users — list users
+// ---------------------------------------------------------------------------
+
+test.describe('MH-012: GET /api/admin/users — list users', () => {
+  test('returns 200 with users array and pagination metadata', async ({ request }) => {
+    const token = await loginAsAdmin(request);
+    const res = await request.get(`${API_URL}/api/admin/users`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.users)).toBe(true);
+    expect(typeof body.total).toBe('number');
+    expect(typeof body.page).toBe('number');
+    expect(typeof body.page_size).toBe('number');
+    // Each user has the expected shape.
+    for (const u of body.users) {
+      expect(typeof u.id).toBe('number');
+      expect(typeof u.username).toBe('string');
+      expect(['admin', 'user']).toContain(u.role);
+      expect(typeof u.active).toBe('boolean');
+      expect(typeof u.created_at).toBe('string');
+    }
+  });
+
+  test('requires authentication', async ({ request }) => {
+    const res = await request.get(`${API_URL}/api/admin/users`);
+    expect(res.status()).toBe(401);
+  });
+
+  test('non-admin token returns 403', async ({ request }) => {
+    const adminToken = await loginAsAdmin(request);
+    const username = `plain-${uid()}`;
+    const userId = await createTestUser(request, adminToken, username, 'user');
+    try {
+      const plainToken = await loginAs(request, username, 'TestPass1!');
+      const res = await request.get(`${API_URL}/api/admin/users`, {
+        headers: { Authorization: `Bearer ${plainToken}` },
+      });
+      expect(res.status()).toBe(403);
+    } finally {
+      await deleteUser(request, adminToken, userId);
+    }
+  });
+
+  test('page_size capped at 200', async ({ request }) => {
+    const token = await loginAsAdmin(request);
+    const res = await request.get(`${API_URL}/api/admin/users?page_size=9999`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.page_size).toBeLessThanOrEqual(200);
+  });
+
+  test('page parameter is respected', async ({ request }) => {
+    const token = await loginAsAdmin(request);
+    const res = await request.get(`${API_URL}/api/admin/users?page=1&page_size=1`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.users.length).toBeLessThanOrEqual(1);
+    expect(body.page).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-2: POST /api/admin/users — create user
+// ---------------------------------------------------------------------------
+
+test.describe('MH-012: POST /api/admin/users — create user', () => {
+  test('creates a new user and returns 201 with id/username/role', async ({ request }) => {
+    const token = await loginAsAdmin(request);
+    const username = `new-${uid()}`;
+    let userId = -1;
+    try {
+      const res = await request.post(`${API_URL}/api/admin/users`, {
+        headers: { Authorization: `Bearer ${token}` },
+        data: { username, password: 'TestPass1!', role: 'user' },
+      });
+      expect(res.status()).toBe(201);
+      const body = await res.json();
+      expect(typeof body.id).toBe('number');
+      expect(body.username).toBe(username);
+      expect(body.role).toBe('user');
+      userId = body.id;
+    } finally {
+      if (userId !== -1) await deleteUser(request, token, userId);
+    }
+  });
+
+  test('created user can log in with the supplied password', async ({ request }) => {
+    const adminToken = await loginAsAdmin(request);
+    const username = `login-${uid()}`;
+    const userId = await createTestUser(request, adminToken, username);
+    try {
+      const loginRes = await request.post(`${API_URL}/api/auth/login`, {
+        data: { username, password: 'TestPass1!' },
+      });
+      expect(loginRes.status()).toBe(200);
+    } finally {
+      await deleteUser(request, adminToken, userId);
+    }
+  });
+
+  test('duplicate username returns 409', async ({ request }) => {
+    const token = await loginAsAdmin(request);
+    const username = `dup-${uid()}`;
+    const userId = await createTestUser(request, token, username);
+    try {
+      const res = await request.post(`${API_URL}/api/admin/users`, {
+        headers: { Authorization: `Bearer ${token}` },
+        data: { username, password: 'other', role: 'user' },
+      });
+      expect(res.status()).toBe(409);
+    } finally {
+      await deleteUser(request, token, userId);
+    }
+  });
+
+  test('missing username returns 400', async ({ request }) => {
+    const token = await loginAsAdmin(request);
+    const res = await request.post(`${API_URL}/api/admin/users`, {
+      headers: { Authorization: `Bearer ${token}` },
+      data: { password: 'TestPass1!', role: 'user' },
+    });
+    expect(res.status()).toBe(400);
+  });
+
+  test('missing password returns 400', async ({ request }) => {
+    const token = await loginAsAdmin(request);
+    const res = await request.post(`${API_URL}/api/admin/users`, {
+      headers: { Authorization: `Bearer ${token}` },
+      data: { username: `nopw-${uid()}`, role: 'user' },
+    });
+    expect(res.status()).toBe(400);
+  });
+
+  test('invalid role returns 400', async ({ request }) => {
+    const token = await loginAsAdmin(request);
+    const res = await request.post(`${API_URL}/api/admin/users`, {
+      headers: { Authorization: `Bearer ${token}` },
+      data: { username: `badrole-${uid()}`, password: 'TestPass1!', role: 'superuser' },
+    });
+    expect(res.status()).toBe(400);
+  });
+
+  test('requires admin role', async ({ request }) => {
+    const adminToken = await loginAsAdmin(request);
+    const username = `plain2-${uid()}`;
+    const userId = await createTestUser(request, adminToken, username);
+    try {
+      const plainToken = await loginAs(request, username, 'TestPass1!');
+      const res = await request.post(`${API_URL}/api/admin/users`, {
+        headers: { Authorization: `Bearer ${plainToken}` },
+        data: { username: `shouldfail-${uid()}`, password: 'x', role: 'user' },
+      });
+      expect(res.status()).toBe(403);
+    } finally {
+      await deleteUser(request, adminToken, userId);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-3: PATCH /api/admin/users/:id — update role / active
+// ---------------------------------------------------------------------------
+
+test.describe('MH-012: PATCH /api/admin/users/:id — update user', () => {
+  test('promotes user to admin', async ({ request }) => {
+    const adminToken = await loginAsAdmin(request);
+    const username = `promote-${uid()}`;
+    const userId = await createTestUser(request, adminToken, username, 'user');
+    try {
+      const res = await request.patch(`${API_URL}/api/admin/users/${userId}`, {
+        headers: { Authorization: `Bearer ${adminToken}` },
+        data: { role: 'admin' },
+      });
+      expect(res.status()).toBe(200);
+      const body = await res.json();
+      expect(body.role).toBe('admin');
+    } finally {
+      await deleteUser(request, adminToken, userId);
+    }
+  });
+
+  test('deactivates a user — login returns 403', async ({ request }) => {
+    const adminToken = await loginAsAdmin(request);
+    const username = `deactivate-${uid()}`;
+    const userId = await createTestUser(request, adminToken, username, 'user');
+    try {
+      const patchRes = await request.patch(`${API_URL}/api/admin/users/${userId}`, {
+        headers: { Authorization: `Bearer ${adminToken}` },
+        data: { active: false },
+      });
+      expect(patchRes.status()).toBe(200);
+      const body = await patchRes.json();
+      expect(body.active).toBe(false);
+
+      // Deactivated user should not be able to log in.
+      const loginRes = await request.post(`${API_URL}/api/auth/login`, {
+        data: { username, password: 'TestPass1!' },
+      });
+      expect(loginRes.status()).toBe(403);
+    } finally {
+      // Re-activate before deletion (deletion may also be blocked on inactive users in future).
+      await request.patch(`${API_URL}/api/admin/users/${userId}`, {
+        headers: { Authorization: `Bearer ${adminToken}` },
+        data: { active: true },
+      });
+      await deleteUser(request, adminToken, userId);
+    }
+  });
+
+  test('re-activating a user restores login', async ({ request }) => {
+    const adminToken = await loginAsAdmin(request);
+    const username = `reactivate-${uid()}`;
+    const userId = await createTestUser(request, adminToken, username, 'user');
+    try {
+      // Deactivate.
+      await request.patch(`${API_URL}/api/admin/users/${userId}`, {
+        headers: { Authorization: `Bearer ${adminToken}` },
+        data: { active: false },
+      });
+      // Re-activate.
+      await request.patch(`${API_URL}/api/admin/users/${userId}`, {
+        headers: { Authorization: `Bearer ${adminToken}` },
+        data: { active: true },
+      });
+      // Should log in successfully.
+      const loginRes = await request.post(`${API_URL}/api/auth/login`, {
+        data: { username, password: 'TestPass1!' },
+      });
+      expect(loginRes.status()).toBe(200);
+    } finally {
+      await deleteUser(request, adminToken, userId);
+    }
+  });
+
+  test('last-admin guard: cannot demote the only admin', async ({ request }) => {
+    const adminToken = await loginAsAdmin(request);
+    // Find the admin user ID.
+    const listRes = await request.get(`${API_URL}/api/admin/users`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+    const { users } = await listRes.json();
+    const adminUsers: Array<{ id: number; username: string; role: string }> = users.filter(
+      (u: { role: string }) => u.role === 'admin',
+    );
+    // Skip if there are multiple admins — guard only fires on the last one.
+    if (adminUsers.length !== 1) return;
+    const adminId = adminUsers[0].id;
+
+    const res = await request.patch(`${API_URL}/api/admin/users/${adminId}`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+      data: { role: 'user' },
+    });
+    expect(res.status()).toBe(409);
+  });
+
+  test('patching non-existent user returns 404', async ({ request }) => {
+    const token = await loginAsAdmin(request);
+    const res = await request.patch(`${API_URL}/api/admin/users/999999`, {
+      headers: { Authorization: `Bearer ${token}` },
+      data: { role: 'user' },
+    });
+    expect(res.status()).toBe(404);
+  });
+
+  test('requires admin role', async ({ request }) => {
+    const adminToken = await loginAsAdmin(request);
+    const username = `patch-plain-${uid()}`;
+    const userId = await createTestUser(request, adminToken, username);
+    try {
+      const plainToken = await loginAs(request, username, 'TestPass1!');
+      const res = await request.patch(`${API_URL}/api/admin/users/${userId}`, {
+        headers: { Authorization: `Bearer ${plainToken}` },
+        data: { role: 'admin' },
+      });
+      expect(res.status()).toBe(403);
+    } finally {
+      await deleteUser(request, adminToken, userId);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-4: DELETE /api/admin/users/:id — delete user
+// ---------------------------------------------------------------------------
+
+test.describe('MH-012: DELETE /api/admin/users/:id — delete user', () => {
+  test('deletes an existing user and returns 204', async ({ request }) => {
+    const token = await loginAsAdmin(request);
+    const username = `del-${uid()}`;
+    const userId = await createTestUser(request, token, username);
+    const res = await request.delete(`${API_URL}/api/admin/users/${userId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status()).toBe(204);
+  });
+
+  test('deleted user cannot log in', async ({ request }) => {
+    const adminToken = await loginAsAdmin(request);
+    const username = `del-login-${uid()}`;
+    const userId = await createTestUser(request, adminToken, username);
+    await deleteUser(request, adminToken, userId);
+
+    const loginRes = await request.post(`${API_URL}/api/auth/login`, {
+      data: { username, password: 'TestPass1!' },
+    });
+    expect(loginRes.status()).toBe(401);
+  });
+
+  test('deleting non-existent user returns 404', async ({ request }) => {
+    const token = await loginAsAdmin(request);
+    const res = await request.delete(`${API_URL}/api/admin/users/999999`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status()).toBe(404);
+  });
+
+  test('last-admin guard: cannot delete the only admin', async ({ request }) => {
+    const adminToken = await loginAsAdmin(request);
+    const listRes = await request.get(`${API_URL}/api/admin/users`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+    const { users } = await listRes.json();
+    const adminUsers: Array<{ id: number; role: string }> = users.filter(
+      (u: { role: string }) => u.role === 'admin',
+    );
+    if (adminUsers.length !== 1) return;
+    const adminId = adminUsers[0].id;
+
+    const res = await request.delete(`${API_URL}/api/admin/users/${adminId}`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.status()).toBe(409);
+  });
+
+  test('cannot delete your own account', async ({ request }) => {
+    const adminToken = await loginAsAdmin(request);
+    // Find the admin's own user id.
+    const listRes = await request.get(`${API_URL}/api/admin/users`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+    const { users } = await listRes.json();
+    const self: { id: number; username: string } | undefined = users.find(
+      (u: { username: string }) => u.username === ADMIN_USER,
+    );
+    if (!self) return; // Can't proceed without knowing self id.
+
+    const res = await request.delete(`${API_URL}/api/admin/users/${self.id}`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    });
+    expect(res.status()).toBe(409);
+  });
+
+  test('requires admin role', async ({ request }) => {
+    const adminToken = await loginAsAdmin(request);
+    const username = `del-plain-${uid()}`;
+    const userId = await createTestUser(request, adminToken, username);
+    try {
+      const plainToken = await loginAs(request, username, 'TestPass1!');
+      const res = await request.delete(`${API_URL}/api/admin/users/${userId}`, {
+        headers: { Authorization: `Bearer ${plainToken}` },
+      });
+      expect(res.status()).toBe(403);
+    } finally {
+      await deleteUser(request, adminToken, userId);
+    }
+  });
+});

--- a/hive-web/src/App.tsx
+++ b/hive-web/src/App.tsx
@@ -23,6 +23,11 @@ function getNavInitials(): string {
 
 const TABS: Tab[] = ["rooms", "agents", "tasks", "costs"];
 
+/** Return the role from the stored JWT, or null if not authenticated. */
+function getStoredRole(): string | null {
+  return getUserFromToken()?.role ?? null;
+}
+
 const API_BASE = import.meta.env.VITE_API_URL || "http://localhost:3000";
 const WS_BASE = API_BASE.replace(/^http/, "ws");
 
@@ -198,6 +203,15 @@ function App() {
         ))}
         <div className="ml-auto flex items-center gap-3">
           <StatusDot status={status} />
+          {getStoredRole() === "admin" && (
+            <a
+              href="/admin/users"
+              data-testid="admin-nav-link"
+              className="px-3 py-1 rounded text-sm text-gray-400 hover:text-gray-200 hover:bg-gray-700 transition-colors"
+            >
+              Admin
+            </a>
+          )}
           <button
             onClick={() => navigate("/profile")}
             data-testid="profile-nav-button"

--- a/hive-web/src/components/UsersPage.tsx
+++ b/hive-web/src/components/UsersPage.tsx
@@ -1,0 +1,411 @@
+/**
+ * MH-012: User management page (admin only).
+ *
+ * Lists all users, allows creating new users, updating roles/status,
+ * and deleting users (with last-admin protection).
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { authHeader } from "../lib/auth";
+
+const API_BASE = import.meta.env.VITE_API_URL || "http://localhost:3000";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface AdminUser {
+  id: number;
+  username: string;
+  role: "admin" | "user";
+  active: boolean;
+  created_at: string;
+}
+
+interface ListUsersResponse {
+  users: AdminUser[];
+  total: number;
+  page: number;
+  page_size: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function apiFetch<T>(
+  path: string,
+  init?: RequestInit
+): Promise<{ ok: true; data: T } | { ok: false; error: string }> {
+  try {
+    const res = await fetch(`${API_BASE}${path}`, {
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        ...authHeader(),
+        ...(init?.headers ?? {}),
+      },
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      return { ok: false, error: body.message ?? `HTTP ${res.status}` };
+    }
+    if (res.status === 204) return { ok: true, data: undefined as T };
+    const data = await res.json();
+    return { ok: true, data };
+  } catch (e) {
+    return { ok: false, error: String(e) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface UsersState {
+  loading: boolean;
+  error: string | null;
+  users: AdminUser[];
+  total: number;
+  page: number;
+  /** Increment to trigger a re-fetch without changing page. */
+  fetchId: number;
+}
+
+export function UsersPage() {
+  const [usersState, setUsersState] = useState<UsersState>({
+    loading: true,
+    error: null,
+    users: [],
+    total: 0,
+    page: 1,
+    fetchId: 0,
+  });
+
+  const PAGE_SIZE = 50;
+  const { loading, error, users, total, page, fetchId } = usersState;
+
+  // Fetch users whenever page or fetchId changes.
+  // No synchronous setState in the effect body — initial state already has loading: true.
+  useEffect(() => {
+    let cancelled = false;
+    apiFetch<ListUsersResponse>(
+      `/api/admin/users?page=${page}&page_size=${PAGE_SIZE}`
+    ).then((result) => {
+      if (cancelled) return;
+      if (!result.ok) {
+        setUsersState((s) => ({ ...s, loading: false, error: result.error }));
+        return;
+      }
+      setUsersState((s) => ({
+        ...s,
+        loading: false,
+        error: null,
+        users: result.data.users,
+        total: result.data.total,
+        page: result.data.page,
+      }));
+    });
+    return () => {
+      cancelled = true;
+    };
+    // fetchId is intentionally included: incrementing it re-runs this effect
+    // without changing page, used after create/delete.
+  }, [page, fetchId]);
+
+  const triggerRefresh = useCallback(
+    () => setUsersState((s) => ({ ...s, loading: true, error: null, fetchId: s.fetchId + 1 })),
+    []
+  );
+
+  const setPage = useCallback(
+    (p: number) => setUsersState((s) => ({ ...s, loading: true, error: null, page: p })),
+    []
+  );
+
+  // Create user form state
+  const [showCreate, setShowCreate] = useState(false);
+  const [newUsername, setNewUsername] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [newRole, setNewRole] = useState<"admin" | "user">("user");
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const handleToggleActive = useCallback(async (user: AdminUser) => {
+    const result = await apiFetch<AdminUser>(`/api/admin/users/${user.id}`, {
+      method: "PATCH",
+      body: JSON.stringify({ active: !user.active }),
+    });
+    if (!result.ok) {
+      setUsersState((s) => ({ ...s, error: result.error }));
+      return;
+    }
+    setUsersState((s) => ({
+      ...s,
+      users: s.users.map((u) => (u.id === user.id ? result.data : u)),
+    }));
+  }, []);
+
+  const handleRoleChange = useCallback(
+    async (user: AdminUser, role: "admin" | "user") => {
+      const result = await apiFetch<AdminUser>(`/api/admin/users/${user.id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ role }),
+      });
+      if (!result.ok) {
+        setUsersState((s) => ({ ...s, error: result.error }));
+        return;
+      }
+      setUsersState((s) => ({
+        ...s,
+        users: s.users.map((u) => (u.id === user.id ? result.data : u)),
+      }));
+    },
+    []
+  );
+
+  const handleDelete = useCallback(
+    async (user: AdminUser) => {
+      const confirmed = window.confirm(
+        `Permanently delete user "${user.username}"?\nThis cannot be undone.`
+      );
+      if (!confirmed) return;
+      const result = await apiFetch<undefined>(`/api/admin/users/${user.id}`, {
+        method: "DELETE",
+      });
+      if (!result.ok) {
+        setUsersState((s) => ({ ...s, error: result.error }));
+        return;
+      }
+      setUsersState((s) => ({
+        ...s,
+        users: s.users.filter((u) => u.id !== user.id),
+        total: s.total - 1,
+      }));
+    },
+    []
+  );
+
+  const handleCreate = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!newUsername.trim() || !newPassword.trim()) {
+        setCreateError("Username and password are required.");
+        return;
+      }
+      setCreating(true);
+      setCreateError(null);
+      const result = await apiFetch<{ id: number; username: string; role: string }>(
+        "/api/admin/users",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            username: newUsername.trim(),
+            password: newPassword,
+            role: newRole,
+          }),
+        }
+      );
+      setCreating(false);
+      if (!result.ok) {
+        setCreateError(result.error);
+        return;
+      }
+      setNewUsername("");
+      setNewPassword("");
+      setNewRole("user");
+      setShowCreate(false);
+      triggerRefresh();
+    },
+    [newUsername, newPassword, newRole, triggerRefresh]
+  );
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <div
+      className="p-6 max-w-4xl mx-auto"
+      data-testid="users-page"
+      role="main"
+    >
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-xl font-semibold text-gray-100">User Management</h1>
+        <button
+          onClick={() => setShowCreate((s) => !s)}
+          data-testid="create-user-button"
+          className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded text-sm font-medium transition-colors"
+        >
+          {showCreate ? "Cancel" : "Add User"}
+        </button>
+      </div>
+
+      {/* Create user form */}
+      {showCreate && (
+        <form
+          onSubmit={handleCreate}
+          className="mb-6 p-4 bg-gray-800 rounded border border-gray-700"
+          data-testid="create-user-form"
+        >
+          <h2 className="text-sm font-semibold text-gray-300 mb-3">New User</h2>
+          <div className="flex gap-3 flex-wrap">
+            <input
+              type="text"
+              placeholder="Username"
+              value={newUsername}
+              onChange={(e) => setNewUsername(e.target.value)}
+              data-testid="new-username-input"
+              className="flex-1 min-w-36 px-3 py-1.5 bg-gray-700 border border-gray-600 rounded text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:border-blue-500"
+              autoComplete="off"
+            />
+            <input
+              type="password"
+              placeholder="Password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              data-testid="new-password-input"
+              className="flex-1 min-w-36 px-3 py-1.5 bg-gray-700 border border-gray-600 rounded text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:border-blue-500"
+              autoComplete="new-password"
+            />
+            <select
+              value={newRole}
+              onChange={(e) => setNewRole(e.target.value as "admin" | "user")}
+              data-testid="new-role-select"
+              className="px-3 py-1.5 bg-gray-700 border border-gray-600 rounded text-sm text-gray-100 focus:outline-none focus:border-blue-500"
+            >
+              <option value="user">user</option>
+              <option value="admin">admin</option>
+            </select>
+            <button
+              type="submit"
+              disabled={creating}
+              className="px-4 py-1.5 bg-green-600 hover:bg-green-700 text-white rounded text-sm font-medium disabled:opacity-50 transition-colors"
+            >
+              {creating ? "Creating…" : "Create"}
+            </button>
+          </div>
+          {createError && (
+            <p className="mt-2 text-sm text-red-400" role="alert">
+              {createError}
+            </p>
+          )}
+        </form>
+      )}
+
+      {/* Error banner */}
+      {error && (
+        <div
+          className="mb-4 p-3 bg-red-900/50 border border-red-700 rounded text-sm text-red-300"
+          role="alert"
+        >
+          {error}
+        </div>
+      )}
+
+      {/* Users table */}
+      {loading ? (
+        <div className="text-sm text-gray-400" role="status">
+          Loading users…
+        </div>
+      ) : (
+        <>
+          <table
+            className="w-full text-sm"
+            aria-label="User list"
+            data-testid="users-table"
+          >
+            <thead>
+              <tr className="text-left text-xs font-semibold text-gray-500 uppercase tracking-wider border-b border-gray-700">
+                <th className="pb-2 pr-4">Username</th>
+                <th className="pb-2 pr-4">Role</th>
+                <th className="pb-2 pr-4">Status</th>
+                <th className="pb-2 pr-4">Created</th>
+                <th className="pb-2" aria-label="Actions" />
+              </tr>
+            </thead>
+            <tbody>
+              {users.map((user) => (
+                <tr
+                  key={user.id}
+                  data-testid={`user-row-${user.id}`}
+                  className="border-b border-gray-800"
+                >
+                  <td className="py-2 pr-4 font-mono text-gray-200">
+                    {user.username}
+                  </td>
+                  <td className="py-2 pr-4">
+                    <select
+                      value={user.role}
+                      onChange={(e) =>
+                        handleRoleChange(
+                          user,
+                          e.target.value as "admin" | "user"
+                        )
+                      }
+                      aria-label={`Role for ${user.username}`}
+                      className="px-2 py-0.5 bg-gray-700 border border-gray-600 rounded text-xs text-gray-200 focus:outline-none focus:border-blue-500"
+                    >
+                      <option value="user">user</option>
+                      <option value="admin">admin</option>
+                    </select>
+                  </td>
+                  <td className="py-2 pr-4">
+                    <button
+                      onClick={() => handleToggleActive(user)}
+                      aria-label={
+                        user.active
+                          ? `Deactivate ${user.username}`
+                          : `Activate ${user.username}`
+                      }
+                      className={`px-2 py-0.5 rounded text-xs font-medium transition-colors ${
+                        user.active
+                          ? "bg-green-900/60 text-green-400 hover:bg-green-900"
+                          : "bg-gray-700 text-gray-400 hover:bg-gray-600"
+                      }`}
+                    >
+                      {user.active ? "active" : "disabled"}
+                    </button>
+                  </td>
+                  <td className="py-2 pr-4 text-gray-500 text-xs">
+                    {user.created_at.slice(0, 10)}
+                  </td>
+                  <td className="py-2">
+                    <button
+                      onClick={() => handleDelete(user)}
+                      aria-label={`Delete ${user.username}`}
+                      className="px-2 py-0.5 rounded text-xs text-red-500 hover:text-red-400 hover:bg-red-900/30 transition-colors"
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div className="flex items-center gap-2 mt-4 text-sm text-gray-400">
+              <button
+                onClick={() => setPage(Math.max(1, page - 1))}
+                disabled={page <= 1}
+                className="px-3 py-1 rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-40 transition-colors"
+              >
+                Prev
+              </button>
+              <span>
+                Page {page} of {totalPages} ({total} users)
+              </span>
+              <button
+                onClick={() => setPage(Math.min(totalPages, page + 1))}
+                disabled={page >= totalPages}
+                className="px-3 py-1 rounded bg-gray-700 hover:bg-gray-600 disabled:opacity-40 transition-colors"
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/hive-web/src/main.tsx
+++ b/hive-web/src/main.tsx
@@ -8,6 +8,7 @@ import { LoginPage } from './components/LoginPage.tsx'
 import { ProfilePage } from './components/ProfilePage.tsx'
 import { RequireAuth } from './components/RequireAuth.tsx'
 import { AuthProvider } from './contexts/AuthContext.tsx'
+import { UsersPage } from './components/UsersPage.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -17,6 +18,16 @@ createRoot(document.getElementById('root')!).render(
           <Routes>
             {/* Public — no auth required */}
             <Route path="/login" element={<LoginPage />} />
+
+            {/* Admin-only — protected + role check enforced server-side */}
+            <Route
+              path="/admin/users"
+              element={
+                <RequireAuth>
+                  <UsersPage />
+                </RequireAuth>
+              }
+            />
 
             {/* Protected — redirect to /login when no token */}
             <Route


### PR DESCRIPTION
## Summary

- **schema v5**: adds `active INTEGER NOT NULL DEFAULT 1` to `local_users`
- **admin.rs** (new): `GET/POST /api/admin/users`, `PATCH/DELETE /api/admin/users/:id`
  - pagination (page/page_size, capped at 200)
  - last-admin guard on role demotion and self-deletion
  - login rejects inactive users (HTTP 403)
- **UsersPage.tsx** (new): paginated table with create form, role selector, active toggle, delete
- **App.tsx**: admin nav link conditional on JWT `role == "admin"`
- **main.tsx**: `/admin/users` route wrapped in `RequireAuth`
- **e2e/user-mgmt-mh012.spec.ts**: 22 Playwright API tests covering all acceptance criteria

## Closes

tb-117 / MH-012

## Test plan

- [ ] `cargo test -p hive-server` — 74 tests pass
- [ ] `npx tsc --noEmit` — no errors
- [ ] `npx eslint src/ e2e/` — no errors
- [ ] Playwright e2e: `npx playwright test e2e/user-mgmt-mh012.spec.ts` against live server