### PR TITLE
feat(hive-web): MH-011 user profile — GET /api/users/me + ProfilePage — tb-116

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Added
+- `GET /api/users/me` endpoint — returns username, role, and ID from JWT claims (MH-011)
+- Profile page at `/profile` — displays avatar initials, username, role badge, and user ID
+- Profile nav button in app header (avatar initials circle) linking to `/profile`

--- a/crates/hive-server/src/main.rs
+++ b/crates/hive-server/src/main.rs
@@ -5,6 +5,7 @@ pub mod db;
 pub mod error;
 mod rest_proxy;
 pub mod settings;
+pub mod users;
 mod ws_relay;
 
 use std::path::PathBuf;
@@ -123,6 +124,7 @@ async fn main() {
     // Protected routes — require valid Bearer JWT.
     let protected_routes = Router::new()
         .route("/api/auth/me", get(auth::me))
+        .route("/api/users/me", get(users::me))
         .route("/api/auth/logout", post(auth::logout))
         .route("/api/rooms", get(rest_proxy::list_rooms))
         .route("/api/rooms/{room_id}", get(rest_proxy::get_room))

--- a/crates/hive-server/src/users.rs
+++ b/crates/hive-server/src/users.rs
@@ -1,0 +1,95 @@
+//! Current-user profile endpoint (MH-011).
+//!
+//! `GET /api/users/me` returns the authenticated user's identity from the
+//! JWT claims injected by [`crate::auth::auth_middleware`].  No database
+//! query is needed — all fields were validated at token-issuance time.
+
+use axum::{Extension, Json};
+use serde::Serialize;
+
+use crate::auth::Claims;
+
+/// Response body for `GET /api/users/me`.
+#[derive(Debug, Serialize)]
+pub struct MeResponse {
+    /// Local user ID (stringified integer from `local_users.id`).
+    pub id: String,
+    /// Login username.
+    pub username: String,
+    /// User role: `"admin"` or `"user"`.
+    pub role: String,
+}
+
+/// `GET /api/users/me` — returns the current user's identity.
+///
+/// Claims are injected by [`crate::auth::auth_middleware`] into Axum request
+/// extensions before reaching this handler.  The response never touches the
+/// database.
+pub(crate) async fn me(Extension(claims): Extension<Claims>) -> Json<MeResponse> {
+    Json(MeResponse {
+        id: claims.sub,
+        username: claims.username,
+        role: claims.role,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::Claims;
+
+    fn make_claims(username: &str, role: &str) -> Claims {
+        Claims {
+            sub: "42".into(),
+            username: username.into(),
+            role: role.into(),
+            jti: uuid::Uuid::new_v4().to_string(),
+            iat: 0,
+            exp: u64::MAX,
+        }
+    }
+
+    #[tokio::test]
+    async fn me_returns_all_fields() {
+        let claims = make_claims("alice", "admin");
+        let Json(resp) = me(Extension(claims)).await;
+        assert_eq!(resp.id, "42");
+        assert_eq!(resp.username, "alice");
+        assert_eq!(resp.role, "admin");
+    }
+
+    #[tokio::test]
+    async fn me_user_role() {
+        let claims = make_claims("bob", "user");
+        let Json(resp) = me(Extension(claims)).await;
+        assert_eq!(resp.role, "user");
+        assert_eq!(resp.username, "bob");
+    }
+
+    #[tokio::test]
+    async fn me_preserves_sub() {
+        let mut claims = make_claims("carol", "user");
+        claims.sub = "99".into();
+        let Json(resp) = me(Extension(claims)).await;
+        assert_eq!(resp.id, "99");
+    }
+
+    #[tokio::test]
+    async fn me_response_serializes() {
+        let claims = make_claims("dave", "admin");
+        let Json(resp) = me(Extension(claims)).await;
+        let json = serde_json::to_value(&resp).unwrap();
+        assert!(json.get("id").is_some(), "must include id");
+        assert!(json.get("username").is_some(), "must include username");
+        assert!(json.get("role").is_some(), "must include role");
+    }
+
+    #[tokio::test]
+    async fn me_username_empty_still_works() {
+        // Edge case: claims with empty username (shouldn't happen in practice
+        // but the handler should not panic on unexpected input).
+        let claims = make_claims("", "user");
+        let Json(resp) = me(Extension(claims)).await;
+        assert_eq!(resp.username, "");
+    }
+}

--- a/hive-web/e2e/profile.spec.ts
+++ b/hive-web/e2e/profile.spec.ts
@@ -1,0 +1,192 @@
+/**
+ * Playwright e2e tests for MH-011 — User Profile page.
+ *
+ * All API calls are intercepted with `page.route()` so no backend is needed.
+ * Tokens are fabricated JWTs — only the payload field is read by the frontend.
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+
+/** Build a fake JWT whose payload decodes to `data`. Signature is not verified. */
+function makeToken(data: {
+  sub: string;
+  username: string;
+  role: string;
+  exp?: number;
+}): string {
+  const header = Buffer.from('{"alg":"HS256","typ":"JWT"}').toString('base64url');
+  const payload = Buffer.from(
+    JSON.stringify({
+      sub: data.sub,
+      username: data.username,
+      role: data.role,
+      jti: 'test-jti',
+      iat: 0,
+      exp: data.exp ?? 9_999_999_999,
+    }),
+  ).toString('base64url');
+  return `${header}.${payload}.fake-signature`;
+}
+
+const DEFAULT_PROFILE = { id: '1', username: 'alice', role: 'admin' };
+const DEFAULT_TOKEN = makeToken({ sub: '1', username: 'alice', role: 'admin' });
+
+/**
+ * Set auth token in localStorage and stub the common protected endpoints.
+ */
+async function setupAuth(
+  page: Page,
+  opts: {
+    profile?: typeof DEFAULT_PROFILE;
+    token?: string;
+    apiStatus?: number;
+  } = {},
+) {
+  const profile = opts.profile ?? DEFAULT_PROFILE;
+  const token = opts.token ?? makeToken({ sub: profile.id, username: profile.username, role: profile.role });
+
+  // Navigate once to set localStorage (must be on the origin first).
+  await page.goto('/login');
+  await page.evaluate((tok) => localStorage.setItem('hive-auth-token', tok), token);
+
+  // Stub /api/users/me
+  if (opts.apiStatus && opts.apiStatus >= 400) {
+    await page.route('**/api/users/me', (route) =>
+      route.fulfill({
+        status: opts.apiStatus!,
+        json: { code: 'INTERNAL_ERROR', message: 'server error' },
+      }),
+    );
+  } else {
+    await page.route('**/api/users/me', (route) =>
+      route.fulfill({ json: profile }),
+    );
+  }
+
+  // Stub other protected endpoints to prevent noise
+  await page.route('**/api/rooms', (route) => route.fulfill({ json: { rooms: [] } }));
+  await page.route('**/api/auth/me', (route) =>
+    route.fulfill({
+      json: { sub: profile.id, username: profile.username, role: profile.role, exp: 9_999_999_999 },
+    }),
+  );
+  await page.route('**/api/auth/logout', (route) =>
+    route.fulfill({ status: 200, json: { message: 'logged out' } }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+test.describe('Profile page', () => {
+  test('renders profile page at /profile', async ({ page }) => {
+    await setupAuth(page);
+    await page.goto('/profile');
+
+    await expect(page.getByTestId('profile-page')).toBeVisible();
+  });
+
+  test('shows username in heading and detail row', async ({ page }) => {
+    await setupAuth(page, { profile: { id: '7', username: 'alice', role: 'admin' } });
+    await page.goto('/profile');
+
+    await expect(page.getByTestId('profile-username-heading')).toHaveText('alice');
+    await expect(page.getByTestId('profile-username-field')).toHaveText('alice');
+  });
+
+  test('shows admin role badge', async ({ page }) => {
+    await setupAuth(page, { profile: { id: '1', username: 'alice', role: 'admin' } });
+    await page.goto('/profile');
+
+    await expect(page.getByTestId('profile-role-badge')).toHaveText('admin');
+    await expect(page.getByTestId('profile-role-field')).toHaveText('admin');
+  });
+
+  test('shows user role badge for non-admin', async ({ page }) => {
+    await setupAuth(page, { profile: { id: '2', username: 'bob', role: 'user' } });
+    await page.goto('/profile');
+
+    await expect(page.getByTestId('profile-role-badge')).toHaveText('user');
+  });
+
+  test('avatar shows two-char initials from username', async ({ page }) => {
+    await setupAuth(page, { profile: { id: '1', username: 'alice', role: 'admin' } });
+    await page.goto('/profile');
+
+    const avatar = page.getByTestId('profile-avatar');
+    await expect(avatar).toBeVisible();
+    await expect(avatar).toHaveText('AL');
+  });
+
+  test('single-char username shows one-char initials', async ({ page }) => {
+    await setupAuth(page, { profile: { id: '3', username: 'x', role: 'user' } });
+    await page.goto('/profile');
+
+    await expect(page.getByTestId('profile-avatar')).toHaveText('X');
+  });
+
+  test('shows user ID in detail row', async ({ page }) => {
+    await setupAuth(page, { profile: { id: '42', username: 'alice', role: 'admin' } });
+    await page.goto('/profile');
+
+    await expect(page.getByTestId('profile-id-field')).toContainText('42');
+  });
+
+  test('back link navigates to home', async ({ page }) => {
+    await setupAuth(page);
+    await page.goto('/profile');
+
+    await page.getByTestId('profile-back-link').click();
+    await expect(page).toHaveURL('/');
+  });
+
+  test('back link is keyboard-focusable', async ({ page }) => {
+    await setupAuth(page);
+    await page.goto('/profile');
+
+    const backLink = page.getByTestId('profile-back-link');
+    await backLink.focus();
+    await expect(backLink).toBeFocused();
+  });
+
+  test('shows error state when API returns 500', async ({ page }) => {
+    await setupAuth(page, { apiStatus: 500 });
+    await page.goto('/profile');
+
+    await expect(page.getByTestId('profile-error-state')).toBeVisible();
+    const errEl = page.getByTestId('profile-error');
+    await expect(errEl).toBeVisible();
+    // Must not show raw status code
+    await expect(errEl).not.toContainText('500');
+  });
+
+  test('error state includes back link', async ({ page }) => {
+    await setupAuth(page, { apiStatus: 503 });
+    await page.goto('/profile');
+
+    await expect(page.getByTestId('profile-error-back')).toBeVisible();
+  });
+
+  test('profile nav button is visible in app', async ({ page }) => {
+    await setupAuth(page);
+    await page.goto('/');
+
+    await expect(page.getByTestId('profile-nav-button')).toBeVisible();
+  });
+
+  test('profile nav button navigates to /profile', async ({ page }) => {
+    await setupAuth(page);
+    await page.goto('/');
+
+    await page.getByTestId('profile-nav-button').click();
+    await expect(page).toHaveURL('/profile');
+    await expect(page.getByTestId('profile-page')).toBeVisible();
+  });
+
+  test('unauthenticated access to /profile redirects to /login', async ({ page }) => {
+    await page.goto('/login');
+    await page.evaluate(() => localStorage.removeItem('hive-auth-token'));
+    await page.goto('/profile');
+
+    await expect(page).toHaveURL(/\/login/);
+  });
+});

--- a/hive-web/src/App.tsx
+++ b/hive-web/src/App.tsx
@@ -10,9 +10,17 @@ import { useWebSocket } from "./hooks/useWebSocket";
 import type { ConnectionStatus } from "./hooks/useWebSocket";
 import type { Room } from "./components/RoomList";
 import type { Member } from "./components/MemberPanel";
-import { authHeader, clearToken } from "./lib/auth";
+import { authHeader, clearToken, getUserFromToken } from "./lib/auth";
 
 type Tab = "rooms" | "agents" | "tasks" | "costs";
+
+/** Extract two-char nav initials from the stored JWT. Returns "?" on failure. */
+function getNavInitials(): string {
+  const user = getUserFromToken();
+  const name = user?.username ?? "";
+  return name.length > 0 ? name.slice(0, 2).toUpperCase() : "?";
+}
+
 const TABS: Tab[] = ["rooms", "agents", "tasks", "costs"];
 
 const API_BASE = import.meta.env.VITE_API_URL || "http://localhost:3000";
@@ -185,6 +193,15 @@ function App() {
         ))}
         <div className="ml-auto flex items-center gap-3">
           <StatusDot status={status} />
+          <button
+            onClick={() => navigate("/profile")}
+            data-testid="profile-nav-button"
+            className="w-7 h-7 rounded-full bg-blue-600 flex items-center justify-center text-xs font-bold hover:bg-blue-500 transition-colors select-none"
+            aria-label="View profile"
+            title="Profile"
+          >
+            {getNavInitials()}
+          </button>
           <button
             onClick={handleLogout}
             disabled={loggingOut}

--- a/hive-web/src/components/ProfilePage.tsx
+++ b/hive-web/src/components/ProfilePage.tsx
@@ -1,0 +1,204 @@
+/**
+ * User profile page (MH-011).
+ *
+ * Displays the current user's identity (username, role, ID) fetched from
+ * `GET /api/users/me`.  All fields are read-only in this version — profile
+ * editing (display name, preferences) is tracked as a follow-up.
+ */
+
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { apiFetch, type AppError } from '../lib/apiError';
+import { authHeader } from '../lib/auth';
+
+const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
+interface UserProfile {
+  id: string;
+  username: string;
+  role: string;
+}
+
+/** Return the first two characters of a username as uppercase initials. */
+function avatarInitials(username: string): string {
+  const trimmed = username.trim();
+  return trimmed.length > 0 ? trimmed.slice(0, 2).toUpperCase() : '??';
+}
+
+/** Colour scheme for role badges. */
+const ROLE_BADGE: Record<string, string> = {
+  admin: 'bg-purple-700 text-purple-100',
+  user: 'bg-gray-700 text-gray-300',
+};
+
+function roleBadgeClass(role: string): string {
+  return ROLE_BADGE[role] ?? 'bg-gray-700 text-gray-300';
+}
+
+/** Full-page loading skeleton. */
+function LoadingState() {
+  return (
+    <div
+      className="min-h-screen bg-gray-900 flex items-center justify-center"
+      data-testid="profile-loading"
+    >
+      <div className="animate-pulse text-gray-400 text-sm">Loading profile…</div>
+    </div>
+  );
+}
+
+/** Full-page error display. */
+function ErrorState({ message }: { message: string }) {
+  return (
+    <div
+      className="min-h-screen bg-gray-900 flex items-center justify-center"
+      data-testid="profile-error-state"
+    >
+      <div className="text-center space-y-4">
+        <p className="text-red-400 text-sm" data-testid="profile-error">
+          {message}
+        </p>
+        <Link
+          to="/"
+          className="text-blue-400 hover:text-blue-300 text-sm underline"
+          data-testid="profile-error-back"
+        >
+          Back to home
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+/** Displays the authenticated user's identity. */
+export function ProfilePage() {
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    apiFetch<UserProfile>(`${API_BASE}/api/users/me`, {
+      headers: authHeader(),
+    })
+      .then((data) => {
+        if (!cancelled) {
+          setProfile(data);
+          setLoading(false);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          const appError = err as AppError;
+          setError(appError?.message ?? 'Could not load your profile.');
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) return <LoadingState />;
+  if (error || !profile) {
+    return <ErrorState message={error ?? 'Could not load your profile.'} />;
+  }
+
+  const initials = avatarInitials(profile.username);
+
+  return (
+    <div
+      className="min-h-screen bg-gray-900 text-gray-100 flex flex-col"
+      data-testid="profile-page"
+    >
+      {/* Navigation bar */}
+      <nav className="px-4 py-3 bg-gray-800 border-b border-gray-700 flex items-center gap-2">
+        <Link
+          to="/"
+          className="text-gray-400 hover:text-gray-200 text-sm transition-colors"
+          data-testid="profile-back-link"
+          aria-label="Back to home"
+        >
+          ← Hive
+        </Link>
+        <span className="text-gray-600 text-sm">/</span>
+        <span className="text-sm font-medium text-gray-200">Profile</span>
+      </nav>
+
+      {/* Main content */}
+      <main className="flex-1 flex items-start justify-center pt-16 px-4">
+        <div className="w-full max-w-md space-y-6">
+          {/* Avatar and identity header */}
+          <div className="flex flex-col items-center gap-3">
+            <div
+              className="w-20 h-20 rounded-full bg-blue-600 flex items-center justify-center text-2xl font-bold select-none"
+              aria-label={`Avatar for ${profile.username}`}
+              data-testid="profile-avatar"
+            >
+              {initials}
+            </div>
+            <div className="text-center">
+              <h1
+                className="text-xl font-semibold"
+                data-testid="profile-username-heading"
+              >
+                {profile.username}
+              </h1>
+              <span
+                className={`mt-1 inline-block px-2 py-0.5 rounded text-xs font-medium ${roleBadgeClass(profile.role)}`}
+                data-testid="profile-role-badge"
+              >
+                {profile.role}
+              </span>
+            </div>
+          </div>
+
+          {/* Profile detail rows */}
+          <div
+            className="bg-gray-800 rounded-lg divide-y divide-gray-700"
+            role="list"
+            aria-label="Profile details"
+          >
+            <div className="px-4 py-3 flex justify-between items-center" role="listitem">
+              <span className="text-sm text-gray-400">Username</span>
+              <span
+                className="text-sm font-medium"
+                data-testid="profile-username-field"
+              >
+                {profile.username}
+              </span>
+            </div>
+
+            <div className="px-4 py-3 flex justify-between items-center" role="listitem">
+              <span className="text-sm text-gray-400">Role</span>
+              <span
+                className="text-sm font-medium capitalize"
+                data-testid="profile-role-field"
+              >
+                {profile.role}
+              </span>
+            </div>
+
+            <div className="px-4 py-3 flex justify-between items-center" role="listitem">
+              <span className="text-sm text-gray-400">User ID</span>
+              <span
+                className="text-sm text-gray-500 font-mono"
+                data-testid="profile-id-field"
+              >
+                #{profile.id}
+              </span>
+            </div>
+          </div>
+
+          {/* Follow-up note */}
+          <p className="text-xs text-gray-500 text-center">
+            Profile editing (display name, avatar, preferences) is coming in a
+            follow-up.
+          </p>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/hive-web/src/main.tsx
+++ b/hive-web/src/main.tsx
@@ -5,6 +5,7 @@ import './index.css'
 import App from './App.tsx'
 import { ErrorBoundary } from './components/ErrorBoundary.tsx'
 import { LoginPage } from './components/LoginPage.tsx'
+import { ProfilePage } from './components/ProfilePage.tsx'
 import { RequireAuth } from './components/RequireAuth.tsx'
 import { AuthProvider } from './contexts/AuthContext.tsx'
 
@@ -18,6 +19,14 @@ createRoot(document.getElementById('root')!).render(
             <Route path="/login" element={<LoginPage />} />
 
             {/* Protected — redirect to /login when no token */}
+            <Route
+              path="/profile"
+              element={
+                <RequireAuth>
+                  <ProfilePage />
+                </RequireAuth>
+              }
+            />
             <Route
               path="/*"
               element={


### PR DESCRIPTION
## Summary
- Backend: `GET /api/users/me` in new `users.rs` — returns `{id, username, role}` from JWT Claims extension injected by `auth_middleware` (no DB query)
- Frontend: `ProfilePage` at `/profile` — avatar initials circle, username, role badge, ID detail row, back link
- App nav: profile button (avatar initials) using `getUserFromToken` from auth.ts
- 14 Playwright e2e tests + 5 Rust unit tests

## Changes
- `crates/hive-server/src/users.rs` (NEW) — `GET /api/users/me` handler + 5 unit tests
- `crates/hive-server/src/main.rs` — wire `/api/users/me` to protected routes
- `hive-web/src/components/ProfilePage.tsx` (NEW) — profile UI
- `hive-web/src/App.tsx` — profile nav button (uses `getUserFromToken` from r2d2's MH-008 auth.ts extension)
- `hive-web/src/main.tsx` — `/profile` route merged with r2d2's `AuthProvider`
- `hive-web/e2e/profile.spec.ts` (NEW) — 14 Playwright tests
- `CHANGELOG.md` (NEW) — first CHANGELOG entry for the hive repo

## Conflict resolution
This PR includes resolved conflicts with PR #132 (r2d2 MH-008 JWT sessions):
- `main.rs`: both `/api/auth/me` and `/api/users/me` kept
- `main.tsx`: `AuthProvider` from #132 + `/profile` route from this PR merged

## Test plan
- [ ] `cargo test -p hive-server` — 69 tests pass (64 upstream + 5 from users.rs)
- [ ] `tsc --noEmit` clean
- [ ] `eslint src/` clean
- [ ] `vite build` succeeds
- [ ] Playwright: `e2e/profile.spec.ts` — 14 tests cover render, username/role, avatar, back link, error states, nav button, unauthenticated redirect

## Checklist
- [x] CHANGELOG entry added under [Unreleased]
- [x] Verified docs and README are accurate after this change (no drift — profile editing deferred to follow-up ticket)
- [x] Test count did not decrease (69 vs 64 — +5 Rust, +14 Playwright)