### PR TITLE
feat(hive): MH-004 first-run setup wizard

### DIFF
--- a/crates/hive-server/src/main.rs
+++ b/crates/hive-server/src/main.rs
@@ -7,6 +7,7 @@ pub mod error;
 mod rest_proxy;
 pub mod rooms;
 pub mod settings;
+pub mod setup;
 pub mod users;
 mod ws_relay;
 
@@ -121,7 +122,12 @@ async fn main() {
     // Public routes — no auth required.
     let public_routes = Router::new()
         .route("/api/health", get(health))
-        .route("/api/auth/login", post(auth::login));
+        .route("/api/auth/login", post(auth::login))
+        .route("/api/setup/status", get(setup::get_status))
+        .route("/api/setup/verify-daemon", post(setup::verify_daemon))
+        .route("/api/setup/configure", post(setup::configure))
+        .route("/api/setup/create-admin", post(setup::create_admin))
+        .route("/api/setup/complete", post(setup::complete));
 
     // Protected routes — require valid Bearer JWT.
     let protected_routes = Router::new()

--- a/crates/hive-server/src/setup.rs
+++ b/crates/hive-server/src/setup.rs
@@ -1,0 +1,373 @@
+//! First-run setup wizard API (MH-004).
+//!
+//! Provides PUBLIC (no-auth) endpoints for the initial Hive setup flow:
+//!
+//! | Endpoint                       | Purpose                                         |
+//! |-------------------------------|--------------------------------------------------|
+//! | `GET  /api/setup/status`       | Check whether setup has been completed           |
+//! | `POST /api/setup/verify-daemon`| Health-check a daemon URL without saving it      |
+//! | `POST /api/setup/configure`    | Write daemon URL to `app_settings`               |
+//! | `POST /api/setup/create-admin` | Create the first admin user (only if none exist) |
+//! | `POST /api/setup/complete`     | Mark `setup_complete = true`                     |
+//!
+//! All mutating endpoints reject requests once `setup_complete` is set.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::response::IntoResponse;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use crate::error::HiveError;
+use crate::AppState;
+
+/// `app_settings` key that records whether setup has been finished.
+pub const KEY_SETUP_COMPLETE: &str = "setup_complete";
+
+// ---------------------------------------------------------------------------
+// Request / response types
+// ---------------------------------------------------------------------------
+
+/// Response body for `GET /api/setup/status`.
+#[derive(Serialize)]
+pub struct SetupStatusResponse {
+    /// `true` when the wizard has been completed at least once.
+    pub setup_complete: bool,
+    /// `true` when at least one local user exists in the database.
+    pub has_admin: bool,
+}
+
+/// Response body for `POST /api/setup/verify-daemon`.
+#[derive(Serialize)]
+pub struct VerifyDaemonResponse {
+    /// Whether the daemon `/api/health` endpoint responded with 2xx.
+    pub reachable: bool,
+    /// Human-readable failure reason, or `null` on success.
+    pub error: Option<String>,
+}
+
+/// Shared response for successful mutation endpoints.
+#[derive(Serialize)]
+pub struct OkResponse {
+    pub message: &'static str,
+}
+
+/// Request body for `POST /api/setup/verify-daemon`.
+#[derive(Deserialize)]
+pub struct VerifyDaemonRequest {
+    /// Full URL to probe (e.g. `ws://daemon:4200` or `http://daemon:4200`).
+    pub url: String,
+}
+
+/// Request body for `POST /api/setup/configure`.
+#[derive(Deserialize)]
+pub struct ConfigureRequest {
+    /// Daemon WebSocket URL to save (e.g. `ws://room-daemon:4200`).
+    pub daemon_url: String,
+}
+
+/// Request body for `POST /api/setup/create-admin`.
+#[derive(Deserialize)]
+pub struct CreateAdminRequest {
+    /// Desired admin username.
+    pub username: String,
+    /// Admin password (min 8 characters; hashed with bcrypt before storage).
+    pub password: String,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Return `true` when `setup_complete = true` is stored in `app_settings`.
+pub fn is_setup_complete(state: &AppState) -> bool {
+    state
+        .db
+        .get_setting(KEY_SETUP_COMPLETE)
+        .ok()
+        .flatten()
+        .as_deref()
+        == Some("true")
+}
+
+/// Return `true` when at least one row exists in `local_users`.
+pub fn has_admin(state: &AppState) -> bool {
+    state
+        .db
+        .with_conn(|conn| {
+            let count: i64 =
+                conn.query_row("SELECT COUNT(*) FROM local_users LIMIT 1", [], |row| {
+                    row.get(0)
+                })?;
+            Ok::<_, rusqlite::Error>(count > 0)
+        })
+        .unwrap_or(false)
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// `GET /api/setup/status` — check whether initial setup has been completed.
+pub(crate) async fn get_status(State(state): State<Arc<AppState>>) -> Json<SetupStatusResponse> {
+    Json(SetupStatusResponse {
+        setup_complete: is_setup_complete(&state),
+        has_admin: has_admin(&state),
+    })
+}
+
+/// `POST /api/setup/verify-daemon` — health-check a URL without saving it.
+///
+/// Sends `GET <url>/api/health` with a 5-second timeout.  Returns
+/// `{ reachable: true }` on a 2xx response, or `{ reachable: false, error }`.
+pub(crate) async fn verify_daemon(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<VerifyDaemonRequest>,
+) -> impl IntoResponse {
+    if is_setup_complete(&state) {
+        return HiveError::BadRequest("setup already complete".into()).into_response();
+    }
+
+    if req.url.is_empty() {
+        return Json(VerifyDaemonResponse {
+            reachable: false,
+            error: Some("url is required".into()),
+        })
+        .into_response();
+    }
+
+    // Normalise ws:// → http:// for the HTTP health-check request.
+    let base = req
+        .url
+        .replace("wss://", "https://")
+        .replace("ws://", "http://");
+
+    match reqwest::Client::new()
+        .get(format!("{base}/api/health"))
+        .timeout(std::time::Duration::from_secs(5))
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => Json(VerifyDaemonResponse {
+            reachable: true,
+            error: None,
+        })
+        .into_response(),
+        Ok(resp) => Json(VerifyDaemonResponse {
+            reachable: false,
+            error: Some(format!("daemon returned HTTP {}", resp.status())),
+        })
+        .into_response(),
+        Err(e) => Json(VerifyDaemonResponse {
+            reachable: false,
+            error: Some(format!("connection failed: {e}")),
+        })
+        .into_response(),
+    }
+}
+
+/// `POST /api/setup/configure` — save the daemon URL to `app_settings`.
+pub(crate) async fn configure(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<ConfigureRequest>,
+) -> Result<Json<OkResponse>, HiveError> {
+    if is_setup_complete(&state) {
+        return Err(HiveError::BadRequest("setup already complete".into()));
+    }
+
+    if req.daemon_url.is_empty() {
+        return Err(HiveError::BadRequest("daemon_url is required".into()));
+    }
+
+    // Validate URL: must parse and use an accepted scheme.
+    let parsed = reqwest::Url::parse(&req.daemon_url)
+        .map_err(|_| HiveError::BadRequest(format!("invalid URL: {}", req.daemon_url)))?;
+
+    if !["ws", "wss", "http", "https"].contains(&parsed.scheme()) {
+        return Err(HiveError::BadRequest(format!(
+            "unsupported scheme '{}': use ws, wss, http, or https",
+            parsed.scheme()
+        )));
+    }
+
+    state
+        .db
+        .set_setting(crate::settings::KEY_DAEMON_URL, &req.daemon_url, "setup")
+        .map_err(|e| HiveError::Internal(format!("db error: {e}")))?;
+
+    tracing::info!(daemon_url = %req.daemon_url, "setup: daemon URL configured");
+
+    Ok(Json(OkResponse {
+        message: "daemon URL saved",
+    }))
+}
+
+/// `POST /api/setup/create-admin` — create the first admin user.
+///
+/// Fails if an admin already exists or if the password is too short.
+/// Uses bcrypt to hash the password before storage.
+pub(crate) async fn create_admin(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<CreateAdminRequest>,
+) -> Result<Json<OkResponse>, HiveError> {
+    if is_setup_complete(&state) {
+        return Err(HiveError::BadRequest("setup already complete".into()));
+    }
+
+    if req.username.is_empty() {
+        return Err(HiveError::BadRequest("username is required".into()));
+    }
+
+    if req.password.len() < 8 {
+        return Err(HiveError::BadRequest(
+            "password must be at least 8 characters".into(),
+        ));
+    }
+
+    if has_admin(&state) {
+        return Err(HiveError::BadRequest("an admin user already exists".into()));
+    }
+
+    let username = req.username.clone();
+    let password = req.password.clone();
+    let db = state.db.clone();
+
+    tokio::task::spawn_blocking(move || {
+        let hash = bcrypt::hash(&password, bcrypt::DEFAULT_COST)
+            .map_err(|e| HiveError::Internal(format!("hash error: {e}")))?;
+
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO local_users (username, password_hash, role) \
+                 VALUES (?1, ?2, 'admin')",
+                rusqlite::params![username, hash],
+            )?;
+            Ok::<_, rusqlite::Error>(())
+        })
+        .map_err(|e| HiveError::Internal(format!("db error: {e}")))?;
+
+        Ok::<_, HiveError>(())
+    })
+    .await
+    .map_err(|e| HiveError::Internal(format!("task error: {e}")))??;
+
+    tracing::info!(username = %req.username, "setup: admin user created");
+
+    Ok(Json(OkResponse {
+        message: "admin user created",
+    }))
+}
+
+/// `POST /api/setup/complete` — finalise setup.
+///
+/// Sets `setup_complete = true` in `app_settings`.  Fails if no admin user
+/// exists yet (the wizard must complete step 2 before calling this).
+pub(crate) async fn complete(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<OkResponse>, HiveError> {
+    if is_setup_complete(&state) {
+        return Err(HiveError::BadRequest("setup already complete".into()));
+    }
+
+    if !has_admin(&state) {
+        return Err(HiveError::BadRequest(
+            "cannot complete setup: create an admin user first".into(),
+        ));
+    }
+
+    state
+        .db
+        .set_setting(KEY_SETUP_COMPLETE, "true", "setup")
+        .map_err(|e| HiveError::Internal(format!("db error: {e}")))?;
+
+    tracing::info!("setup: wizard completed — setup_complete=true");
+
+    Ok(Json(OkResponse {
+        message: "setup complete",
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::Database;
+
+    fn mk_state(db: Database) -> AppState {
+        AppState {
+            config: crate::config::HiveConfig::default(),
+            db,
+            jwt_secret: b"test-secret-at-least-32-bytes-long!".to_vec(),
+            jwt_ttl: 86_400,
+            start_time: std::time::Instant::now(),
+        }
+    }
+
+    #[test]
+    fn setup_not_complete_when_key_missing() {
+        let db = Database::open_memory().unwrap();
+        let state = mk_state(db);
+        assert!(!is_setup_complete(&state));
+    }
+
+    #[test]
+    fn setup_complete_after_setting_key() {
+        let db = Database::open_memory().unwrap();
+        db.set_setting(KEY_SETUP_COMPLETE, "true", "test").unwrap();
+        let state = mk_state(db);
+        assert!(is_setup_complete(&state));
+    }
+
+    #[test]
+    fn setup_incomplete_when_key_is_false() {
+        let db = Database::open_memory().unwrap();
+        db.set_setting(KEY_SETUP_COMPLETE, "false", "test").unwrap();
+        let state = mk_state(db);
+        assert!(!is_setup_complete(&state));
+    }
+
+    #[test]
+    fn has_admin_false_when_no_users() {
+        let db = Database::open_memory().unwrap();
+        let state = mk_state(db);
+        assert!(!has_admin(&state));
+    }
+
+    #[test]
+    fn has_admin_true_after_insert() {
+        let db = Database::open_memory().unwrap();
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO local_users (username, password_hash, role) \
+                 VALUES ('admin', 'hash', 'admin')",
+                [],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+        let state = mk_state(db);
+        assert!(has_admin(&state));
+    }
+
+    #[test]
+    fn complete_rejected_when_no_admin() {
+        let db = Database::open_memory().unwrap();
+        let state = mk_state(db);
+        // is_setup_complete is false, but has_admin is also false — complete should fail.
+        assert!(!has_admin(&state));
+    }
+
+    #[test]
+    fn is_setup_complete_false_by_default_on_new_db() {
+        let db = Database::open_memory().unwrap();
+        let state = mk_state(db);
+        assert!(
+            !is_setup_complete(&state),
+            "new database should not be marked as complete"
+        );
+    }
+}

--- a/hive-web/e2e/mh004-setup.spec.ts
+++ b/hive-web/e2e/mh004-setup.spec.ts
@@ -1,0 +1,249 @@
+/**
+ * MH-004: First-run setup wizard API tests
+ *
+ * Tests the five public setup endpoints:
+ *   GET  /api/setup/status
+ *   POST /api/setup/verify-daemon
+ *   POST /api/setup/configure
+ *   POST /api/setup/create-admin
+ *   POST /api/setup/complete
+ *
+ * The test environment seeds an admin user via HIVE_ADMIN_USER/HIVE_ADMIN_PASSWORD
+ * but does NOT automatically mark setup_complete=true, so the setup endpoints
+ * are callable. Tests that change state accept either success or "setup already
+ * complete" (idempotent test design).
+ *
+ * Validation tests (wrong input, bad URL scheme, short password) never change
+ * server state and are unconditionally asserted.
+ */
+
+import { test, expect } from '@playwright/test';
+
+const API_URL = process.env.HIVE_API_URL || 'http://localhost:3000';
+
+// ---------------------------------------------------------------------------
+// AC-1: GET /api/setup/status
+// ---------------------------------------------------------------------------
+
+test.describe('MH-004: GET /api/setup/status', () => {
+  test('returns 200 with setup_complete and has_admin fields', async ({ request }) => {
+    const res = await request.get(`${API_URL}/api/setup/status`);
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(typeof body.setup_complete).toBe('boolean');
+    expect(typeof body.has_admin).toBe('boolean');
+  });
+
+  test('does not require authentication', async ({ request }) => {
+    // No Authorization header — must still return 200.
+    const res = await request.get(`${API_URL}/api/setup/status`);
+    expect(res.status()).toBe(200);
+  });
+
+  test('has_admin=true when admin was seeded from env', async ({ request }) => {
+    const res = await request.get(`${API_URL}/api/setup/status`);
+    const body = await res.json();
+    // HIVE_ADMIN_USER env var seeds an admin at startup.
+    expect(body.has_admin).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-2: POST /api/setup/verify-daemon
+// ---------------------------------------------------------------------------
+
+test.describe('MH-004: POST /api/setup/verify-daemon', () => {
+  test('returns reachable=false for an unreachable URL', async ({ request }) => {
+    const res = await request.post(`${API_URL}/api/setup/verify-daemon`, {
+      data: { url: 'ws://127.0.0.1:19999' },
+    });
+    // verify-daemon may return 200 or 400 depending on whether setup is complete.
+    // If setup is complete it returns 400; otherwise 200 with reachable=false.
+    if (res.status() === 200) {
+      const body = await res.json();
+      expect(body.reachable).toBe(false);
+      expect(typeof body.error).toBe('string');
+    } else {
+      expect(res.status()).toBe(400);
+    }
+  });
+
+  test('returns reachable=false with error for empty URL', async ({ request }) => {
+    const res = await request.post(`${API_URL}/api/setup/verify-daemon`, {
+      data: { url: '' },
+    });
+    if (res.status() === 200) {
+      const body = await res.json();
+      expect(body.reachable).toBe(false);
+      expect(body.error).toBeTruthy();
+    } else {
+      expect(res.status()).toBe(400);
+    }
+  });
+
+  test('normalises ws:// to http:// for the health check', async ({ request }) => {
+    // A ws:// URL that is not reachable should still return a structured response.
+    const res = await request.post(`${API_URL}/api/setup/verify-daemon`, {
+      data: { url: 'ws://daemon.test.invalid:4200' },
+    });
+    if (res.status() === 200) {
+      const body = await res.json();
+      expect(body).toHaveProperty('reachable');
+    } else {
+      expect(res.status()).toBe(400);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-3: POST /api/setup/configure — validation
+// ---------------------------------------------------------------------------
+
+test.describe('MH-004: POST /api/setup/configure — validation', () => {
+  test('rejects empty daemon_url with 400', async ({ request }) => {
+    const res = await request.post(`${API_URL}/api/setup/configure`, {
+      data: { daemon_url: '' },
+    });
+    expect(res.status()).toBe(400);
+  });
+
+  test('rejects URL with unsupported scheme with 400', async ({ request }) => {
+    const res = await request.post(`${API_URL}/api/setup/configure`, {
+      data: { daemon_url: 'ftp://daemon:4200' },
+    });
+    expect(res.status()).toBe(400);
+  });
+
+  test('rejects a non-URL string with 400', async ({ request }) => {
+    const res = await request.post(`${API_URL}/api/setup/configure`, {
+      data: { daemon_url: 'not-a-url' },
+    });
+    expect(res.status()).toBe(400);
+  });
+
+  test('accepts a valid ws:// URL or returns setup-complete', async ({ request }) => {
+    const res = await request.post(`${API_URL}/api/setup/configure`, {
+      data: { daemon_url: 'ws://room-daemon:4200' },
+    });
+    // 200 = success (setup not yet complete), 400 = "setup already complete"
+    expect([200, 400]).toContain(res.status());
+    if (res.status() === 200) {
+      const body = await res.json();
+      expect(body.message).toBeTruthy();
+    }
+  });
+
+  test('accepts a valid http:// URL or returns setup-complete', async ({ request }) => {
+    const res = await request.post(`${API_URL}/api/setup/configure`, {
+      data: { daemon_url: 'http://room-daemon:4200' },
+    });
+    expect([200, 400]).toContain(res.status());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-4: POST /api/setup/create-admin — validation
+// ---------------------------------------------------------------------------
+
+test.describe('MH-004: POST /api/setup/create-admin — validation', () => {
+  test('rejects empty username with 400', async ({ request }) => {
+    const res = await request.post(`${API_URL}/api/setup/create-admin`, {
+      data: { username: '', password: 'password123' },
+    });
+    expect(res.status()).toBe(400);
+  });
+
+  test('rejects password shorter than 8 characters with 400', async ({ request }) => {
+    const res = await request.post(`${API_URL}/api/setup/create-admin`, {
+      data: { username: 'admin2', password: 'short' },
+    });
+    expect(res.status()).toBe(400);
+  });
+
+  test('rejects when admin already exists or setup complete', async ({ request }) => {
+    // In the test environment the admin is always seeded, so this must fail.
+    const res = await request.post(`${API_URL}/api/setup/create-admin`, {
+      data: { username: 'newadmin', password: 'newpassword' },
+    });
+    expect(res.status()).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-5: POST /api/setup/complete
+// ---------------------------------------------------------------------------
+
+test.describe('MH-004: POST /api/setup/complete', () => {
+  test('succeeds or returns already-complete (idempotent)', async ({ request }) => {
+    const res = await request.post(`${API_URL}/api/setup/complete`);
+    // 200 = marked complete, 400 = already complete
+    expect([200, 400]).toContain(res.status());
+    if (res.status() === 200) {
+      const body = await res.json();
+      expect(body.message).toBeTruthy();
+    }
+  });
+
+  test('status reflects setup_complete after complete call', async ({ request }) => {
+    // Ensure complete is called first.
+    await request.post(`${API_URL}/api/setup/complete`);
+
+    const statusRes = await request.get(`${API_URL}/api/setup/status`);
+    const body = await statusRes.json();
+    // setup_complete may be true (if our call succeeded) or was already true.
+    expect(typeof body.setup_complete).toBe('boolean');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-6: Endpoints reject mutation after setup is complete
+// ---------------------------------------------------------------------------
+
+test.describe('MH-004: post-completion lockout', () => {
+  test.beforeAll(async ({ request }) => {
+    // Mark setup complete so we can verify lockout.
+    await request.post(`${API_URL}/api/setup/complete`);
+  });
+
+  test('configure returns 400 after setup_complete', async ({ request }) => {
+    // After setup is complete, configure must reject.
+    const statusRes = await request.get(`${API_URL}/api/setup/status`);
+    const { setup_complete } = await statusRes.json();
+
+    if (!setup_complete) {
+      // If we can't get to a complete state (e.g. no admin), skip gracefully.
+      test.skip();
+    }
+
+    const res = await request.post(`${API_URL}/api/setup/configure`, {
+      data: { daemon_url: 'ws://daemon:4200' },
+    });
+    expect(res.status()).toBe(400);
+  });
+
+  test('create-admin returns 400 after setup_complete', async ({ request }) => {
+    const statusRes = await request.get(`${API_URL}/api/setup/status`);
+    const { setup_complete } = await statusRes.json();
+
+    if (!setup_complete) {
+      test.skip();
+    }
+
+    const res = await request.post(`${API_URL}/api/setup/create-admin`, {
+      data: { username: 'attacker', password: 'hacked123' },
+    });
+    expect(res.status()).toBe(400);
+  });
+
+  test('complete returns 400 when already complete', async ({ request }) => {
+    const statusRes = await request.get(`${API_URL}/api/setup/status`);
+    const { setup_complete } = await statusRes.json();
+
+    if (!setup_complete) {
+      test.skip();
+    }
+
+    const res = await request.post(`${API_URL}/api/setup/complete`);
+    expect(res.status()).toBe(400);
+  });
+});

--- a/hive-web/src/components/SetupGuard.tsx
+++ b/hive-web/src/components/SetupGuard.tsx
@@ -1,0 +1,84 @@
+/**
+ * SetupGuard — redirects to /setup when the first-run wizard is incomplete (MH-004).
+ *
+ * Checks GET /api/setup/status on first render. While the status is loading,
+ * children are not rendered (avoids a flash of the protected app). Once the
+ * status resolves:
+ *
+ * - setup_complete=true  → render children normally
+ * - setup_complete=false → redirect to /setup
+ *
+ * The /setup route itself must NOT be wrapped by SetupGuard to avoid a loop.
+ */
+
+import { type ReactNode, useEffect, useState } from 'react';
+import { Navigate } from 'react-router-dom';
+
+const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
+interface SetupStatusResponse {
+  setup_complete: boolean;
+  has_admin: boolean;
+}
+
+interface SetupGuardProps {
+  children: ReactNode;
+}
+
+/**
+ * Wrap protected routes with SetupGuard to enforce first-run wizard completion.
+ *
+ * @example
+ * <Route path="/*" element={<SetupGuard><RequireAuth><App /></RequireAuth></SetupGuard>} />
+ */
+export function SetupGuard({ children }: SetupGuardProps) {
+  const [status, setStatus] = useState<'loading' | 'complete' | 'incomplete'>('loading');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetch(`${API_BASE}/api/setup/status`)
+      .then((res) => res.json() as Promise<SetupStatusResponse>)
+      .then((data) => {
+        if (!cancelled) {
+          setStatus(data.setup_complete ? 'complete' : 'incomplete');
+        }
+      })
+      .catch(() => {
+        // If the server is unreachable treat as incomplete so the wizard
+        // can surface the connectivity problem.
+        if (!cancelled) setStatus('incomplete');
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (status === 'loading') {
+    // Minimal spinner; avoids layout flash while fetching status.
+    return (
+      <div
+        className="min-h-screen bg-gray-900 flex items-center justify-center"
+        data-testid="setup-guard-loading"
+      >
+        <svg
+          aria-label="Loading"
+          className="animate-spin h-8 w-8 text-blue-500"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+        >
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+        </svg>
+      </div>
+    );
+  }
+
+  if (status === 'incomplete') {
+    return <Navigate to="/setup" replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/hive-web/src/components/SetupWizard.tsx
+++ b/hive-web/src/components/SetupWizard.tsx
@@ -1,0 +1,440 @@
+/**
+ * First-run setup wizard (MH-004).
+ *
+ * Three-step flow:
+ *  1. Daemon URL — test connection, then save
+ *  2. Admin user — create the first local admin account
+ *  3. Complete  — finalise setup and redirect to /login
+ *
+ * All five setup endpoints are public (no JWT required).
+ */
+
+import { type FormEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { FieldError } from './FieldError';
+
+const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type Step = 'daemon' | 'admin' | 'complete';
+
+// ---------------------------------------------------------------------------
+// Top-level wizard
+// ---------------------------------------------------------------------------
+
+/**
+ * Full-screen setup wizard accessible at /setup.
+ * Hides itself once setup_complete=true (redirects to /login).
+ */
+export function SetupWizard() {
+  const navigate = useNavigate();
+  const [step, setStep] = useState<Step>('daemon');
+  const [daemonUrl, setDaemonUrl] = useState('');
+
+  return (
+    <div
+      className="min-h-screen bg-gray-900 flex items-center justify-center px-4"
+      data-testid="setup-wizard"
+    >
+      <div className="bg-gray-800 rounded-lg shadow-xl p-8 w-full max-w-md">
+        {/* Header */}
+        <h1 className="text-2xl font-bold text-white mb-1">Hive Setup</h1>
+        <p className="text-gray-400 text-sm mb-6">
+          Complete this one-time configuration to get started.
+        </p>
+
+        {/* Step indicator */}
+        <StepIndicator current={step} />
+
+        {/* Step content */}
+        <div className="mt-6">
+          {step === 'daemon' && (
+            <DaemonStep
+              daemonUrl={daemonUrl}
+              onDaemonUrlChange={setDaemonUrl}
+              onNext={() => setStep('admin')}
+            />
+          )}
+          {step === 'admin' && (
+            <AdminStep onNext={() => setStep('complete')} />
+          )}
+          {step === 'complete' && (
+            <CompleteStep onDone={() => navigate('/login', { replace: true })} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step indicator
+// ---------------------------------------------------------------------------
+
+const STEPS: { id: Step; label: string }[] = [
+  { id: 'daemon', label: 'Daemon' },
+  { id: 'admin', label: 'Admin' },
+  { id: 'complete', label: 'Complete' },
+];
+
+function StepIndicator({ current }: { current: Step }) {
+  const currentIndex = STEPS.findIndex((s) => s.id === current);
+
+  return (
+    <div className="flex items-center gap-2" aria-label="Setup progress" role="list">
+      {STEPS.map((s, i) => {
+        const done = i < currentIndex;
+        const active = s.id === current;
+        return (
+          <div key={s.id} className="flex items-center gap-2" role="listitem">
+            {i > 0 && <div className="flex-1 h-px bg-gray-600 w-6" />}
+            <div className="flex flex-col items-center">
+              <div
+                className={`w-7 h-7 rounded-full flex items-center justify-center text-sm font-medium ${
+                  done
+                    ? 'bg-green-600 text-white'
+                    : active
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-600 text-gray-400'
+                }`}
+                aria-current={active ? 'step' : undefined}
+              >
+                {done ? '✓' : i + 1}
+              </div>
+              <span
+                className={`text-xs mt-1 ${active ? 'text-white' : 'text-gray-500'}`}
+              >
+                {s.label}
+              </span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 1: Daemon URL
+// ---------------------------------------------------------------------------
+
+interface DaemonStepProps {
+  daemonUrl: string;
+  onDaemonUrlChange: (url: string) => void;
+  onNext: () => void;
+}
+
+function DaemonStep({ daemonUrl, onDaemonUrlChange, onNext }: DaemonStepProps) {
+  const [testStatus, setTestStatus] = useState<'idle' | 'testing' | 'ok' | 'fail'>('idle');
+  const [testError, setTestError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const handleTest = async () => {
+    setTestStatus('testing');
+    setTestError(null);
+
+    try {
+      const res = await fetch(`${API_BASE}/api/setup/verify-daemon`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: daemonUrl }),
+      });
+      const data = (await res.json()) as { reachable: boolean; error?: string };
+      if (data.reachable) {
+        setTestStatus('ok');
+      } else {
+        setTestStatus('fail');
+        setTestError(data.error ?? 'Daemon unreachable');
+      }
+    } catch {
+      setTestStatus('fail');
+      setTestError('Could not reach the server — check your connection.');
+    }
+  };
+
+  const handleSave = async (e: FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setSaveError(null);
+
+    try {
+      const res = await fetch(`${API_BASE}/api/setup/configure`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ daemon_url: daemonUrl }),
+      });
+
+      if (res.ok) {
+        onNext();
+        return;
+      }
+
+      const data = (await res.json()) as { message?: string };
+      setSaveError(data.message ?? 'Failed to save daemon URL.');
+    } catch {
+      setSaveError('Could not reach the server — check your connection.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSave} noValidate className="space-y-4" data-testid="setup-step-daemon">
+      <div>
+        <label
+          htmlFor="daemon-url"
+          className="block text-sm font-medium text-gray-300 mb-1"
+        >
+          Daemon URL
+        </label>
+        <input
+          id="daemon-url"
+          type="url"
+          autoFocus
+          required
+          value={daemonUrl}
+          onChange={(e) => {
+            onDaemonUrlChange(e.target.value);
+            setTestStatus('idle');
+          }}
+          placeholder="ws://room-daemon:4200"
+          data-testid="setup-daemon-url"
+          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+        />
+        <p className="mt-1 text-xs text-gray-500">
+          WebSocket URL of the room daemon (ws:// or wss://).
+        </p>
+      </div>
+
+      {/* Test result */}
+      {testStatus === 'ok' && (
+        <div
+          role="status"
+          data-testid="setup-daemon-test-ok"
+          className="rounded-md bg-green-900 border border-green-700 px-3 py-2 text-sm text-green-200"
+        >
+          Daemon is reachable.
+        </div>
+      )}
+      {testStatus === 'fail' && (
+        <div
+          role="alert"
+          data-testid="setup-daemon-test-fail"
+          className="rounded-md bg-red-900 border border-red-700 px-3 py-2 text-sm text-red-200"
+        >
+          {testError}
+        </div>
+      )}
+
+      <FieldError message={saveError} />
+
+      <div className="flex gap-3">
+        <button
+          type="button"
+          disabled={!daemonUrl || testStatus === 'testing'}
+          onClick={handleTest}
+          data-testid="setup-daemon-test-btn"
+          className="flex-1 py-2 px-4 bg-gray-600 hover:bg-gray-500 disabled:bg-gray-700 disabled:cursor-not-allowed text-white font-medium rounded-md transition-colors"
+        >
+          {testStatus === 'testing' ? 'Testing…' : 'Test connection'}
+        </button>
+        <button
+          type="submit"
+          disabled={!daemonUrl || saving}
+          data-testid="setup-daemon-save-btn"
+          className="flex-1 py-2 px-4 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-800 disabled:cursor-not-allowed text-white font-medium rounded-md transition-colors"
+        >
+          {saving ? 'Saving…' : 'Save & continue'}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 2: Create admin user
+// ---------------------------------------------------------------------------
+
+interface AdminStepProps {
+  onNext: () => void;
+}
+
+function AdminStep({ onNext }: AdminStepProps) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`${API_BASE}/api/setup/create-admin`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      });
+
+      if (res.ok) {
+        onNext();
+        return;
+      }
+
+      const data = (await res.json()) as { message?: string };
+      setError(data.message ?? 'Failed to create admin user.');
+    } catch {
+      setError('Could not reach the server — check your connection.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} noValidate className="space-y-4" data-testid="setup-step-admin">
+      <div>
+        <label
+          htmlFor="admin-username"
+          className="block text-sm font-medium text-gray-300 mb-1"
+        >
+          Admin username
+        </label>
+        <input
+          id="admin-username"
+          type="text"
+          autoComplete="username"
+          autoFocus
+          required
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          placeholder="admin"
+          data-testid="setup-admin-username"
+          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="admin-password"
+          className="block text-sm font-medium text-gray-300 mb-1"
+        >
+          Password
+        </label>
+        <div className="relative">
+          <input
+            id="admin-password"
+            type={showPassword ? 'text' : 'password'}
+            autoComplete="new-password"
+            required
+            minLength={8}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="••••••••"
+            data-testid="setup-admin-password"
+            className="w-full px-3 py-2 pr-10 bg-gray-700 border border-gray-600 rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          />
+          <button
+            type="button"
+            onClick={() => setShowPassword((v) => !v)}
+            aria-label={showPassword ? 'Hide password' : 'Show password'}
+            data-testid="setup-toggle-password"
+            className="absolute inset-y-0 right-0 px-3 flex items-center text-gray-400 hover:text-gray-200 focus:outline-none"
+          >
+            {showPassword ? (
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94" />
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19" />
+                <line x1="1" y1="1" x2="23" y2="23" strokeLinecap="round" />
+              </svg>
+            ) : (
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                <circle cx="12" cy="12" r="3" />
+              </svg>
+            )}
+          </button>
+        </div>
+        <p className="mt-1 text-xs text-gray-500">Minimum 8 characters.</p>
+      </div>
+
+      <FieldError message={error} />
+
+      <button
+        type="submit"
+        disabled={!username || password.length < 8 || loading}
+        data-testid="setup-admin-submit"
+        className="w-full py-2 px-4 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-800 disabled:cursor-not-allowed text-white font-medium rounded-md transition-colors"
+      >
+        {loading ? 'Creating…' : 'Create admin & continue'}
+      </button>
+    </form>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step 3: Complete
+// ---------------------------------------------------------------------------
+
+interface CompleteStepProps {
+  onDone: () => void;
+}
+
+function CompleteStep({ onDone }: CompleteStepProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleComplete = async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`${API_BASE}/api/setup/complete`, {
+        method: 'POST',
+      });
+
+      if (res.ok) {
+        onDone();
+        return;
+      }
+
+      const data = (await res.json()) as { message?: string };
+      setError(data.message ?? 'Failed to complete setup.');
+    } catch {
+      setError('Could not reach the server — check your connection.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4" data-testid="setup-step-complete">
+      <div className="rounded-md bg-gray-700 px-4 py-3 text-sm text-gray-200 space-y-1">
+        <p className="font-medium text-white">Setup summary</p>
+        <p>✓ Daemon URL configured</p>
+        <p>✓ Admin user created</p>
+      </div>
+
+      <p className="text-sm text-gray-400">
+        Click below to finalise setup. You will be redirected to the login page.
+      </p>
+
+      <FieldError message={error} />
+
+      <button
+        type="button"
+        disabled={loading}
+        onClick={handleComplete}
+        data-testid="setup-complete-btn"
+        className="w-full py-2 px-4 bg-green-600 hover:bg-green-700 disabled:bg-green-800 disabled:cursor-not-allowed text-white font-medium rounded-md transition-colors"
+      >
+        {loading ? 'Finishing…' : 'Finish setup'}
+      </button>
+    </div>
+  );
+}

--- a/hive-web/src/main.tsx
+++ b/hive-web/src/main.tsx
@@ -7,6 +7,8 @@ import { ErrorBoundary } from './components/ErrorBoundary.tsx'
 import { LoginPage } from './components/LoginPage.tsx'
 import { ProfilePage } from './components/ProfilePage.tsx'
 import { RequireAuth } from './components/RequireAuth.tsx'
+import { SetupGuard } from './components/SetupGuard.tsx'
+import { SetupWizard } from './components/SetupWizard.tsx'
 import { AuthProvider } from './contexts/AuthContext.tsx'
 import { UsersPage } from './components/UsersPage.tsx'
 
@@ -16,6 +18,9 @@ createRoot(document.getElementById('root')!).render(
       <AuthProvider>
         <ErrorBoundary>
           <Routes>
+            {/* First-run wizard — public, no SetupGuard to avoid redirect loop */}
+            <Route path="/setup" element={<SetupWizard />} />
+
             {/* Public — no auth required */}
             <Route path="/login" element={<LoginPage />} />
 
@@ -29,7 +34,7 @@ createRoot(document.getElementById('root')!).render(
               }
             />
 
-            {/* Protected — redirect to /login when no token */}
+            {/* Protected — setup must be complete, then auth required */}
             <Route
               path="/profile"
               element={
@@ -41,9 +46,11 @@ createRoot(document.getElementById('root')!).render(
             <Route
               path="/*"
               element={
-                <RequireAuth>
-                  <App />
-                </RequireAuth>
+                <SetupGuard>
+                  <RequireAuth>
+                    <App />
+                  </RequireAuth>
+                </SetupGuard>
               }
             />
           </Routes>


### PR DESCRIPTION
## Summary

- **Backend**: 5 public (no-JWT) setup endpoints in `setup.rs` — status check, daemon URL verification, daemon URL save, admin user creation, and setup completion. All mutating endpoints reject after `setup_complete=true`.
- **Frontend**: `SetupWizard` (3-step UI: daemon → admin → complete) and `SetupGuard` (redirects to `/setup` when incomplete); `main.tsx` updated with `/setup` route and `SetupGuard` wrapping the protected catch-all.
- **Tests**: 7 Rust unit tests for helper functions; 18 Playwright API tests covering all 5 endpoints including validation rejection, post-completion lockout, and idempotent assertions.

## Changed files

- `crates/hive-server/src/setup.rs` — NEW: 5 setup handlers + helpers + unit tests
- `crates/hive-server/src/main.rs` — add `pub mod setup`, wire 5 routes into `public_routes`
- `hive-web/src/components/SetupWizard.tsx` — NEW: 3-step first-run wizard
- `hive-web/src/components/SetupGuard.tsx` — NEW: setup-complete gate for protected routes
- `hive-web/src/main.tsx` — add `/setup` route, wrap `/*` with `SetupGuard`
- `hive-web/e2e/mh004-setup.spec.ts` — NEW: 18 Playwright API tests

## Test plan

- [x] `cargo test` — 81 tests pass
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt --check` — clean
- [x] ESLint on new/changed frontend files — no errors
- [x] TypeScript `--noEmit` — no type errors
- [ ] Playwright tests (requires running hive-server with HIVE_ADMIN_USER/HIVE_ADMIN_PASSWORD)

Closes tb-118
