### PR TITLE
feat(rooms): MH-014 create room modal — tb-119

### DIFF
--- a/hive-web/e2e/create-room-mh014.spec.ts
+++ b/hive-web/e2e/create-room-mh014.spec.ts
@@ -1,0 +1,240 @@
+/**
+ * MH-014: Create room — UI and backend integration
+ *
+ * UI tests use mocked API responses (no backend required).
+ * API tests require a running server with valid credentials.
+ */
+
+import { test, expect } from '@playwright/test';
+
+const API_URL = process.env.HIVE_API_URL || 'http://localhost:3000';
+const ADMIN_USER = process.env.HIVE_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.HIVE_ADMIN_PASSWORD || 'test-password';
+
+const MOCK_TOKEN = 'mock-jwt-token-mh014';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Set up a page with a mocked auth token and mocked room list + create APIs. */
+async function setupAuthenticatedPage(
+  page: import('@playwright/test').Page,
+  initialRooms: Array<{ id: string; name: string }> = [],
+) {
+  await page.addInitScript((token: string) => {
+    localStorage.setItem('hive-auth-token', token);
+  }, MOCK_TOKEN);
+
+  // Mock GET /api/rooms
+  await page.route('**/api/rooms', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          rooms: initialRooms.map((r) => ({
+            ...r,
+            workspace_id: 1,
+            workspace_name: 'default',
+            added_at: new Date().toISOString(),
+          })),
+          total: initialRooms.length,
+        }),
+      });
+    } else {
+      // POST — return the new room
+      const body = route.request().postDataJSON() as { name: string };
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: body.name.toLowerCase(),
+          name: body.name.toLowerCase(),
+          workspace_id: 1,
+        }),
+      });
+    }
+  });
+
+  await page.goto('/rooms');
+}
+
+// ---------------------------------------------------------------------------
+// Modal open/close
+// ---------------------------------------------------------------------------
+
+test.describe('MH-014: create room modal — open and close', () => {
+  test('clicking + button opens the create room modal', async ({ page }) => {
+    await setupAuthenticatedPage(page);
+    const plusBtn = page.getByTestId('create-room-button');
+    await plusBtn.click();
+    await expect(page.getByTestId('create-room-modal')).toBeVisible();
+  });
+
+  test('empty state "Create your first room" opens the modal', async ({ page }) => {
+    await setupAuthenticatedPage(page, []);
+    await expect(page.getByText('Create your first room')).toBeVisible();
+    await page.getByText('Create your first room').click();
+    await expect(page.getByTestId('create-room-modal')).toBeVisible();
+  });
+
+  test('Cancel button closes the modal', async ({ page }) => {
+    await setupAuthenticatedPage(page);
+    await page.getByTestId('create-room-button').click();
+    await page.getByRole('button', { name: 'Cancel' }).click();
+    await expect(page.getByTestId('create-room-modal')).not.toBeVisible();
+  });
+
+  test('Escape key closes the modal', async ({ page }) => {
+    await setupAuthenticatedPage(page);
+    await page.getByTestId('create-room-button').click();
+    await expect(page.getByTestId('create-room-modal')).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId('create-room-modal')).not.toBeVisible();
+  });
+
+  test('clicking backdrop closes the modal', async ({ page }) => {
+    await setupAuthenticatedPage(page);
+    await page.getByTestId('create-room-button').click();
+    // Click the backdrop (outside the dialog box)
+    await page.mouse.click(10, 10);
+    await expect(page.getByTestId('create-room-modal')).not.toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Form validation
+// ---------------------------------------------------------------------------
+
+test.describe('MH-014: create room modal — form validation', () => {
+  test('submit button is disabled when name is empty', async ({ page }) => {
+    await setupAuthenticatedPage(page);
+    await page.getByTestId('create-room-button').click();
+    await expect(page.getByTestId('create-room-submit')).toBeDisabled();
+  });
+
+  test('shows inline error for invalid characters', async ({ page }) => {
+    await setupAuthenticatedPage(page);
+    await page.getByTestId('create-room-button').click();
+    await page.getByTestId('room-name-input').fill('bad name!');
+    await expect(page.getByText(/letters, numbers, hyphens/)).toBeVisible();
+    await expect(page.getByTestId('create-room-submit')).toBeDisabled();
+  });
+
+  test('clears error when valid name entered', async ({ page }) => {
+    await setupAuthenticatedPage(page);
+    await page.getByTestId('create-room-button').click();
+    await page.getByTestId('room-name-input').fill('bad name!');
+    await page.getByTestId('room-name-input').fill('good-name');
+    await expect(page.getByText(/letters, numbers, hyphens/)).not.toBeVisible();
+    await expect(page.getByTestId('create-room-submit')).not.toBeDisabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Successful create
+// ---------------------------------------------------------------------------
+
+test.describe('MH-014: create room — success flow', () => {
+  test('creates room and closes modal on success', async ({ page }) => {
+    await setupAuthenticatedPage(page);
+    await page.getByTestId('create-room-button').click();
+    await page.getByTestId('room-name-input').fill('my-new-room');
+    await page.getByTestId('create-room-submit').click();
+    await expect(page.getByTestId('create-room-modal')).not.toBeVisible();
+  });
+
+  test('new room appears in sidebar after creation', async ({ page }) => {
+    await setupAuthenticatedPage(page, [{ id: 'existing', name: 'existing' }]);
+    await page.getByTestId('create-room-button').click();
+    await page.getByTestId('room-name-input').fill('brand-new');
+    await page.getByTestId('create-room-submit').click();
+    await expect(page.getByText('#brand-new')).toBeVisible();
+  });
+
+  test('description field is optional', async ({ page }) => {
+    await setupAuthenticatedPage(page);
+    await page.getByTestId('create-room-button').click();
+    await page.getByTestId('room-name-input').fill('nodesc-room');
+    // Leave description empty
+    await page.getByTestId('create-room-submit').click();
+    await expect(page.getByTestId('create-room-modal')).not.toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+test.describe('MH-014: create room — error handling', () => {
+  test('shows server error message on 400 response', async ({ page }) => {
+    await page.addInitScript((token: string) => {
+      localStorage.setItem('hive-auth-token', token);
+    }, MOCK_TOKEN);
+
+    await page.route('**/api/rooms', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ rooms: [], total: 0 }),
+        });
+      } else {
+        await route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'room name may only contain alphanumerics' }),
+        });
+      }
+    });
+
+    await page.goto('/rooms');
+    await page.getByTestId('create-room-button').click();
+    await page.getByTestId('room-name-input').fill('valid-name');
+    await page.getByTestId('create-room-submit').click();
+    await expect(page.getByTestId('create-room-error')).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// API tests (requires running backend)
+// ---------------------------------------------------------------------------
+
+test.describe('MH-014: POST /api/rooms — API validation', () => {
+  async function getToken(request: Parameters<Parameters<typeof test>[1]>[0]['request']): Promise<string> {
+    const res = await request.post(`${API_URL}/api/auth/login`, {
+      data: { username: ADMIN_USER, password: ADMIN_PASSWORD },
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    return body.token as string;
+  }
+
+  test('POST /api/rooms returns 201 with valid name', async ({ request }) => {
+    const token = await getToken(request);
+    const res = await request.post(`${API_URL}/api/rooms`, {
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      data: { name: `ui-test-${Date.now()}` },
+    });
+    expect(res.status()).toBe(201);
+    const body = await res.json();
+    expect(typeof body.id).toBe('string');
+  });
+
+  test('POST /api/rooms returns 400 for spaces in name', async ({ request }) => {
+    const token = await getToken(request);
+    const res = await request.post(`${API_URL}/api/rooms`, {
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      data: { name: 'has space' },
+    });
+    expect(res.status()).toBe(400);
+  });
+
+  test('POST /api/rooms returns 401 without token', async ({ request }) => {
+    const res = await request.post(`${API_URL}/api/rooms`, {
+      data: { name: 'no-auth' },
+    });
+    expect(res.status()).toBe(401);
+  });
+});

--- a/hive-web/src/App.tsx
+++ b/hive-web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { RoomList } from "./components/RoomList";
+import { CreateRoomModal } from "./components/CreateRoomModal";
 import ChatTimeline from "./components/ChatTimeline";
 import { MemberPanel } from "./components/MemberPanel";
 import { MessageInput } from "./components/MessageInput";
@@ -58,6 +59,7 @@ function App() {
   const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
   const [rooms, setRooms] = useState<Room[]>([]);
   const [loggingOut, setLoggingOut] = useState(false);
+  const [showCreateRoom, setShowCreateRoom] = useState(false);
 
   /** Invalidate the server-side token and clear local auth state. */
   const handleLogout = useCallback(async () => {
@@ -150,6 +152,17 @@ function App() {
     [selectedRoomId, clearMessages]
   );
 
+  /** Called after a room is successfully created: add it to the list and select it. */
+  const handleRoomCreated = useCallback((roomId: string) => {
+    setRooms((prev) => {
+      if (prev.some((r) => r.id === roomId)) return prev;
+      return [{ id: roomId, name: roomId, unreadCount: 0 }, ...prev];
+    });
+    clearMessages();
+    setSelectedRoomId(roomId);
+    setShowCreateRoom(false);
+  }, [clearMessages]);
+
   // Handle sending messages
   const handleSend = useCallback(
     (content: string) => {
@@ -223,8 +236,21 @@ function App() {
       <div className="flex flex-1 overflow-hidden">
         {/* Left sidebar */}
         <aside className="w-60 bg-gray-800 border-r border-gray-700 flex flex-col sidebar">
-          <div className="p-3 text-xs font-semibold text-gray-500 uppercase tracking-wider">
-            {activeTab}
+          <div className="px-3 py-2 flex items-center justify-between">
+            <span className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
+              {activeTab}
+            </span>
+            {activeTab === "rooms" && (
+              <button
+                onClick={() => setShowCreateRoom(true)}
+                aria-label="Create room"
+                data-testid="create-room-button"
+                className="text-gray-500 hover:text-gray-200 transition-colors text-lg leading-none"
+                title="Create room"
+              >
+                +
+              </button>
+            )}
           </div>
           <div className="flex-1 overflow-y-auto">
             {activeTab === "rooms" ? (
@@ -232,6 +258,7 @@ function App() {
                 rooms={rooms}
                 selectedRoomId={selectedRoomId}
                 onSelectRoom={handleSelectRoom}
+                onCreateRoom={() => setShowCreateRoom(true)}
               />
             ) : (
               <div className="px-3 py-2 text-sm text-gray-500">
@@ -299,6 +326,14 @@ function App() {
         <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-yellow-600 text-white px-4 py-2 rounded-lg shadow-lg text-sm">
           Reconnecting to {selectedRoomId}...
         </div>
+      )}
+
+      {/* Create room modal */}
+      {showCreateRoom && (
+        <CreateRoomModal
+          onCreated={handleRoomCreated}
+          onClose={() => setShowCreateRoom(false)}
+        />
       )}
     </div>
   );

--- a/hive-web/src/components/CreateRoomModal.tsx
+++ b/hive-web/src/components/CreateRoomModal.tsx
@@ -1,0 +1,172 @@
+/**
+ * CreateRoomModal — form to create a new room (MH-014).
+ *
+ * Calls POST /api/rooms with the room name and optional description.
+ * Calls `onCreated` with the new room ID on success so the parent can
+ * select it immediately.
+ */
+
+import { type FormEvent, useState, useEffect, useRef } from "react";
+import { authHeader } from "../lib/auth";
+import { FieldError } from "./FieldError";
+
+const API_BASE = import.meta.env.VITE_API_URL || "http://localhost:3000";
+
+const NAME_PATTERN = /^[a-zA-Z0-9_-]{1,80}$/;
+
+interface CreateRoomResponse {
+  id: string;
+  name: string;
+  workspace_id: number;
+}
+
+interface CreateRoomModalProps {
+  onCreated: (roomId: string) => void;
+  onClose: () => void;
+}
+
+export function CreateRoomModal({ onCreated, onClose }: CreateRoomModalProps) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const nameRef = useRef<HTMLInputElement>(null);
+
+  // Auto-focus name field on mount
+  useEffect(() => {
+    nameRef.current?.focus();
+  }, []);
+
+  // Close on Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  const nameError = name.length > 0 && !NAME_PATTERN.test(name)
+    ? "Name must be 1–80 characters: letters, numbers, hyphens, underscores only"
+    : null;
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!NAME_PATTERN.test(name)) {
+      setError("Invalid room name.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`${API_BASE}/api/rooms`, {
+        method: "POST",
+        headers: { ...authHeader(), "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name,
+          description: description.trim() || undefined,
+        }),
+      });
+
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        setError(body.error ?? `Unexpected error (${res.status})`);
+        return;
+      }
+
+      const created = (await res.json()) as CreateRoomResponse;
+      onCreated(created.id);
+    } catch {
+      setError("Network error — could not reach server.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    /* Backdrop */
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      data-testid="create-room-modal"
+    >
+      <div className="bg-gray-800 rounded-lg shadow-xl w-full max-w-md mx-4 p-6">
+        <h2 className="text-lg font-semibold text-gray-100 mb-4">
+          Create a room
+        </h2>
+
+        <form onSubmit={handleSubmit} noValidate>
+          <div className="mb-4">
+            <label
+              htmlFor="room-name"
+              className="block text-sm font-medium text-gray-300 mb-1"
+            >
+              Room name
+            </label>
+            <input
+              ref={nameRef}
+              id="room-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. general"
+              maxLength={80}
+              className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded text-gray-100 placeholder-gray-500 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              data-testid="room-name-input"
+            />
+            {nameError && <FieldError message={nameError} />}
+          </div>
+
+          <div className="mb-5">
+            <label
+              htmlFor="room-description"
+              className="block text-sm font-medium text-gray-300 mb-1"
+            >
+              Description{" "}
+              <span className="text-gray-500 font-normal">(optional)</span>
+            </label>
+            <input
+              id="room-description"
+              type="text"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What is this room for?"
+              className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded text-gray-100 placeholder-gray-500 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              data-testid="room-description-input"
+            />
+          </div>
+
+          {error && (
+            <p
+              className="mb-4 text-sm text-red-400"
+              data-testid="create-room-error"
+            >
+              {error}
+            </p>
+          )}
+
+          <div className="flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm text-gray-400 hover:text-gray-200 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting || !name || !!nameError}
+              className="px-4 py-2 text-sm font-medium bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              data-testid="create-room-submit"
+            >
+              {submitting ? "Creating…" : "Create room"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Replaces #137 (rebased onto master after tb-116 profile changes).

- **CreateRoomModal** component: name field (1–80 chars, alphanumeric/hyphens/underscores with inline validation), optional description, server error display, Escape key + backdrop close, auto-focus on open
- **"+" button** added to rooms sidebar header to open the modal
- **Empty-state action** "Create your first room" opens the modal
- After creation: new room added to the list and selected automatically
- Backend is already in master — `POST /api/rooms` from PR #134

## Test plan

- [ ] `npx tsc --noEmit` — no type errors
- [ ] `npx eslint src/ e2e/` — no errors
- [ ] Click "+" → modal opens with name field focused
- [ ] Empty name → submit disabled
- [ ] `bad name!` → inline error shown, submit disabled
- [ ] `good-name` + submit → modal closes, room appears in sidebar selected
- [ ] Escape → modal closes
- [ ] Click backdrop → modal closes
- [ ] 14 Playwright tests in create-room-mh014.spec.ts