### PR TITLE
feat(rooms): DELETE /api/rooms/:room_id + DeleteRoomModal (MH-015)

### DIFF
--- a/crates/hive-server/src/main.rs
+++ b/crates/hive-server/src/main.rs
@@ -146,7 +146,10 @@ async fn main() {
             "/api/rooms",
             get(rooms::list_rooms).post(rooms::create_room),
         )
-        .route("/api/rooms/{room_id}", get(rest_proxy::get_room))
+        .route(
+            "/api/rooms/{room_id}",
+            get(rest_proxy::get_room).delete(rooms::delete_room),
+        )
         .route(
             "/api/rooms/{room_id}/messages",
             get(rest_proxy::get_messages),

--- a/crates/hive-server/src/rooms.rs
+++ b/crates/hive-server/src/rooms.rs
@@ -1,4 +1,4 @@
-//! Room management API — MH-016 (list rooms) and MH-014 (create room).
+//! Room management API — MH-016 (list rooms), MH-014 (create room), MH-015 (delete room).
 //!
 //! Rooms are stored in Hive's DB (`workspace_rooms` table, scoped to a
 //! workspace). This module replaces the placeholder `list_rooms` stub in
@@ -9,7 +9,12 @@
 
 use std::sync::Arc;
 
-use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::AppState;
@@ -219,6 +224,39 @@ pub async fn create_room(
     }
 }
 
+/// `DELETE /api/rooms/:room_id` — remove a room from the database.
+///
+/// Hard-deletes the `workspace_rooms` row. Returns 204 on success, 404 if the
+/// room does not exist.
+pub async fn delete_room(
+    State(state): State<Arc<AppState>>,
+    Path(room_id): Path<String>,
+) -> impl IntoResponse {
+    let result = state.db.with_conn(|conn| {
+        let rows = conn.execute(
+            "DELETE FROM workspace_rooms WHERE room_id = ?1",
+            rusqlite::params![room_id],
+        )?;
+        Ok(rows)
+    });
+
+    match result {
+        Ok(0) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "room not found"})),
+        )
+            .into_response(),
+        Ok(_) => {
+            tracing::info!(room_id = %room_id, "room deleted");
+            StatusCode::NO_CONTENT.into_response()
+        }
+        Err(e) => {
+            tracing::error!("failed to delete room '{room_id}': {e}");
+            (StatusCode::INTERNAL_SERVER_ERROR, "internal error").into_response()
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -317,5 +355,77 @@ mod tests {
             .unwrap();
 
         assert_eq!(room_id, "room-dev");
+    }
+
+    #[test]
+    fn delete_existing_room_returns_one() {
+        let db = crate::db::Database::open_memory().unwrap();
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO users (provider, provider_id) VALUES ('test', '1')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO workspaces (name, owner_id) VALUES ('default', 1)",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO workspace_rooms (workspace_id, room_id) VALUES (1, 'to-delete')",
+                [],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+        let rows = db
+            .with_conn(|conn| {
+                conn.execute(
+                    "DELETE FROM workspace_rooms WHERE room_id = ?1",
+                    rusqlite::params!["to-delete"],
+                )
+            })
+            .unwrap();
+
+        assert_eq!(rows, 1);
+
+        // Room is gone
+        let count: i64 = db
+            .with_conn(|conn| {
+                conn.query_row(
+                    "SELECT COUNT(*) FROM workspace_rooms WHERE room_id = 'to-delete'",
+                    [],
+                    |row| row.get(0),
+                )
+            })
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn delete_nonexistent_room_returns_zero() {
+        let db = crate::db::Database::open_memory().unwrap();
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO users (provider, provider_id) VALUES ('test', '1')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO workspaces (name, owner_id) VALUES ('default', 1)",
+                [],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+        let rows = db
+            .with_conn(|conn| {
+                conn.execute(
+                    "DELETE FROM workspace_rooms WHERE room_id = ?1",
+                    rusqlite::params!["does-not-exist"],
+                )
+            })
+            .unwrap();
+
+        assert_eq!(rows, 0);
     }
 }

--- a/hive-web/e2e/delete-room-mh015.spec.ts
+++ b/hive-web/e2e/delete-room-mh015.spec.ts
@@ -1,0 +1,285 @@
+/**
+ * MH-015: Delete room — UI and backend integration
+ *
+ * UI tests use mocked API responses (no backend required).
+ * API tests require a running server with valid credentials.
+ */
+
+import { test, expect } from '@playwright/test';
+
+const API_URL = process.env.HIVE_API_URL || 'http://localhost:3000';
+const ADMIN_USER = process.env.HIVE_ADMIN_USER || 'admin';
+const ADMIN_PASSWORD = process.env.HIVE_ADMIN_PASSWORD || 'test-password';
+
+const MOCK_TOKEN = 'mock-jwt-token-mh015';
+const TEST_ROOM = { id: 'room-to-delete', name: 'room-to-delete' };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Set up a page with a mocked token, a room list, and a DELETE stub.
+ * Navigates to /rooms, clicks the room, and waits for the header to appear.
+ */
+async function setupWithRoom(
+  page: import('@playwright/test').Page,
+  deleteStatus = 204,
+) {
+  await page.addInitScript((token: string) => {
+    localStorage.setItem('hive-auth-token', token);
+  }, MOCK_TOKEN);
+
+  // Mock GET /api/rooms
+  await page.route('**/api/rooms', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        rooms: [
+          {
+            ...TEST_ROOM,
+            workspace_id: 1,
+            workspace_name: 'default',
+            added_at: new Date().toISOString(),
+          },
+        ],
+        total: 1,
+      }),
+    });
+  });
+
+  // Mock DELETE /api/rooms/:room_id
+  await page.route(`**/api/rooms/${TEST_ROOM.id}`, async (route) => {
+    if (route.request().method() !== 'DELETE') {
+      await route.continue();
+      return;
+    }
+    if (deleteStatus === 204) {
+      await route.fulfill({ status: 204 });
+    } else if (deleteStatus === 404) {
+      await route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'room not found' }),
+      });
+    } else {
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'internal error' }),
+      });
+    }
+  });
+
+  await page.goto('/rooms');
+
+  // Select the room so the room header appears
+  await page.getByText(`#${TEST_ROOM.id}`).click();
+  await expect(page.getByTestId('delete-room-button')).toBeVisible();
+}
+
+// ---------------------------------------------------------------------------
+// Modal open/close
+// ---------------------------------------------------------------------------
+
+test.describe('MH-015: delete room modal — open and close', () => {
+  test('trash icon is visible when a room is selected', async ({ page }) => {
+    await setupWithRoom(page);
+    await expect(page.getByTestId('delete-room-button')).toBeVisible();
+  });
+
+  test('clicking trash icon opens the delete room modal', async ({ page }) => {
+    await setupWithRoom(page);
+    await page.getByTestId('delete-room-button').click();
+    await expect(page.getByTestId('delete-room-modal')).toBeVisible();
+  });
+
+  test('Cancel button closes the modal', async ({ page }) => {
+    await setupWithRoom(page);
+    await page.getByTestId('delete-room-button').click();
+    await page.getByRole('button', { name: 'Cancel' }).click();
+    await expect(page.getByTestId('delete-room-modal')).not.toBeVisible();
+  });
+
+  test('Escape key closes the modal', async ({ page }) => {
+    await setupWithRoom(page);
+    await page.getByTestId('delete-room-button').click();
+    await expect(page.getByTestId('delete-room-modal')).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId('delete-room-modal')).not.toBeVisible();
+  });
+
+  test('clicking backdrop closes the modal', async ({ page }) => {
+    await setupWithRoom(page);
+    await page.getByTestId('delete-room-button').click();
+    await page.mouse.click(10, 10);
+    await expect(page.getByTestId('delete-room-modal')).not.toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Confirmation input
+// ---------------------------------------------------------------------------
+
+test.describe('MH-015: delete room modal — confirmation', () => {
+  test('delete button is disabled before typing the room name', async ({ page }) => {
+    await setupWithRoom(page);
+    await page.getByTestId('delete-room-button').click();
+    await expect(page.getByTestId('delete-room-submit')).toBeDisabled();
+  });
+
+  test('delete button is disabled when partial name entered', async ({ page }) => {
+    await setupWithRoom(page);
+    await page.getByTestId('delete-room-button').click();
+    await page.getByTestId('delete-room-confirmation-input').fill('room-to');
+    await expect(page.getByTestId('delete-room-submit')).toBeDisabled();
+  });
+
+  test('delete button is enabled only when full room name matches', async ({ page }) => {
+    await setupWithRoom(page);
+    await page.getByTestId('delete-room-button').click();
+    await page.getByTestId('delete-room-confirmation-input').fill(TEST_ROOM.id);
+    await expect(page.getByTestId('delete-room-submit')).not.toBeDisabled();
+  });
+
+  test('modal shows the room name in the instructions', async ({ page }) => {
+    await setupWithRoom(page);
+    await page.getByTestId('delete-room-button').click();
+    await expect(page.getByTestId('delete-room-modal')).toContainText(TEST_ROOM.id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Success flow
+// ---------------------------------------------------------------------------
+
+test.describe('MH-015: delete room — success flow', () => {
+  test('modal closes after successful deletion', async ({ page }) => {
+    await setupWithRoom(page);
+    await page.getByTestId('delete-room-button').click();
+    await page.getByTestId('delete-room-confirmation-input').fill(TEST_ROOM.id);
+    await page.getByTestId('delete-room-submit').click();
+    await expect(page.getByTestId('delete-room-modal')).not.toBeVisible();
+  });
+
+  test('deleted room is removed from sidebar', async ({ page }) => {
+    await setupWithRoom(page);
+    await page.getByTestId('delete-room-button').click();
+    await page.getByTestId('delete-room-confirmation-input').fill(TEST_ROOM.id);
+    await page.getByTestId('delete-room-submit').click();
+    await expect(page.getByText(`#${TEST_ROOM.id}`)).not.toBeVisible();
+  });
+
+  test('room header is hidden after deletion (room deselected)', async ({ page }) => {
+    await setupWithRoom(page);
+    await page.getByTestId('delete-room-button').click();
+    await page.getByTestId('delete-room-confirmation-input').fill(TEST_ROOM.id);
+    await page.getByTestId('delete-room-submit').click();
+    await expect(page.getByTestId('delete-room-button')).not.toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+test.describe('MH-015: delete room — error handling', () => {
+  test('shows error when server returns 404', async ({ page }) => {
+    await setupWithRoom(page, 404);
+    await page.getByTestId('delete-room-button').click();
+    await page.getByTestId('delete-room-confirmation-input').fill(TEST_ROOM.id);
+    await page.getByTestId('delete-room-submit').click();
+    await expect(page.getByTestId('delete-room-error')).toBeVisible();
+    await expect(page.getByTestId('delete-room-error')).toContainText('already been deleted');
+  });
+
+  test('shows generic error on server failure', async ({ page }) => {
+    await setupWithRoom(page, 500);
+    await page.getByTestId('delete-room-button').click();
+    await page.getByTestId('delete-room-confirmation-input').fill(TEST_ROOM.id);
+    await page.getByTestId('delete-room-submit').click();
+    await expect(page.getByTestId('delete-room-error')).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// API tests (requires running backend)
+// ---------------------------------------------------------------------------
+
+test.describe('MH-015: DELETE /api/rooms/:room_id — API tests', () => {
+  async function getToken(request: Parameters<Parameters<typeof test>[1]>[0]['request']): Promise<string> {
+    const res = await request.post(`${API_URL}/api/auth/login`, {
+      data: { username: ADMIN_USER, password: ADMIN_PASSWORD },
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    return body.token as string;
+  }
+
+  async function createRoom(
+    request: Parameters<Parameters<typeof test>[1]>[0]['request'],
+    token: string,
+    name: string,
+  ): Promise<string> {
+    const res = await request.post(`${API_URL}/api/rooms`, {
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      data: { name },
+    });
+    expect(res.status()).toBe(201);
+    const body = await res.json();
+    return body.id as string;
+  }
+
+  test('DELETE /api/rooms/:id returns 204 for existing room', async ({ request }) => {
+    const token = await getToken(request);
+    const roomId = await createRoom(request, token, `del-test-${Date.now()}`);
+    const res = await request.delete(`${API_URL}/api/rooms/${roomId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status()).toBe(204);
+  });
+
+  test('DELETE /api/rooms/:id returns 404 for non-existent room', async ({ request }) => {
+    const token = await getToken(request);
+    const res = await request.delete(`${API_URL}/api/rooms/does-not-exist-xyz`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status()).toBe(404);
+  });
+
+  test('DELETE /api/rooms/:id returns 401 without token', async ({ request }) => {
+    const res = await request.delete(`${API_URL}/api/rooms/some-room`);
+    expect(res.status()).toBe(401);
+  });
+
+  test('room is absent from GET /api/rooms after deletion', async ({ request }) => {
+    const token = await getToken(request);
+    const roomId = await createRoom(request, token, `del-verify-${Date.now()}`);
+
+    // Confirm it exists first
+    const listBefore = await request.get(`${API_URL}/api/rooms`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const bodyBefore = await listBefore.json();
+    const ids: string[] = bodyBefore.rooms.map((r: { id: string }) => r.id);
+    expect(ids).toContain(roomId);
+
+    // Delete it
+    await request.delete(`${API_URL}/api/rooms/${roomId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    // Confirm it is gone
+    const listAfter = await request.get(`${API_URL}/api/rooms`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const bodyAfter = await listAfter.json();
+    const idsAfter: string[] = bodyAfter.rooms.map((r: { id: string }) => r.id);
+    expect(idsAfter).not.toContain(roomId);
+  });
+});

--- a/hive-web/src/App.tsx
+++ b/hive-web/src/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { RoomList } from "./components/RoomList";
 import { CreateRoomModal } from "./components/CreateRoomModal";
+import { DeleteRoomModal } from "./components/DeleteRoomModal";
 import ChatTimeline from "./components/ChatTimeline";
 import { MemberPanel } from "./components/MemberPanel";
 import { MessageInput } from "./components/MessageInput";
@@ -65,6 +66,7 @@ function App() {
   const [rooms, setRooms] = useState<Room[]>([]);
   const [loggingOut, setLoggingOut] = useState(false);
   const [showCreateRoom, setShowCreateRoom] = useState(false);
+  const [showDeleteRoom, setShowDeleteRoom] = useState(false);
 
   /** Invalidate the server-side token and clear local auth state. */
   const handleLogout = useCallback(async () => {
@@ -167,6 +169,14 @@ function App() {
     setSelectedRoomId(roomId);
     setShowCreateRoom(false);
   }, [clearMessages]);
+
+  /** Called after a room is successfully deleted: remove it from the list and deselect. */
+  const handleRoomDeleted = useCallback(() => {
+    setRooms((prev) => prev.filter((r) => r.id !== selectedRoomId));
+    clearMessages();
+    setSelectedRoomId(null);
+    setShowDeleteRoom(false);
+  }, [selectedRoomId, clearMessages]);
 
   // Handle sending messages
   const handleSend = useCallback(
@@ -287,8 +297,17 @@ function App() {
           {activeTab === "rooms" && selectedRoomId ? (
             <>
               {/* Room header */}
-              <div className="px-4 py-2 border-b border-gray-700 bg-gray-800">
+              <div className="px-4 py-2 border-b border-gray-700 bg-gray-800 flex items-center justify-between">
                 <h2 className="text-sm font-semibold">#{selectedRoomId}</h2>
+                <button
+                  onClick={() => setShowDeleteRoom(true)}
+                  aria-label="Delete room"
+                  data-testid="delete-room-button"
+                  className="text-gray-500 hover:text-red-400 transition-colors"
+                  title="Delete room"
+                >
+                  🗑
+                </button>
               </div>
               {/* Chat timeline */}
               <div className="flex-1 overflow-y-auto" data-testid="chat-timeline">
@@ -347,6 +366,15 @@ function App() {
         <CreateRoomModal
           onCreated={handleRoomCreated}
           onClose={() => setShowCreateRoom(false)}
+        />
+      )}
+
+      {/* Delete room modal */}
+      {showDeleteRoom && selectedRoomId && (
+        <DeleteRoomModal
+          roomId={selectedRoomId}
+          onDeleted={handleRoomDeleted}
+          onClose={() => setShowDeleteRoom(false)}
         />
       )}
     </div>

--- a/hive-web/src/components/DeleteRoomModal.tsx
+++ b/hive-web/src/components/DeleteRoomModal.tsx
@@ -1,0 +1,139 @@
+/**
+ * DeleteRoomModal — confirmation dialog to delete a room (MH-015).
+ *
+ * Requires the user to type the room name to confirm before the delete
+ * button becomes active. Calls DELETE /api/rooms/:room_id on submit and
+ * invokes `onDeleted` so the parent can deselect the room.
+ */
+
+import { type FormEvent, useState, useEffect, useRef } from "react";
+import { authHeader } from "../lib/auth";
+
+const API_BASE = import.meta.env.VITE_API_URL || "http://localhost:3000";
+
+interface DeleteRoomModalProps {
+  roomId: string;
+  onDeleted: () => void;
+  onClose: () => void;
+}
+
+export function DeleteRoomModal({
+  roomId,
+  onDeleted,
+  onClose,
+}: DeleteRoomModalProps) {
+  const [confirmation, setConfirmation] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Auto-focus confirmation input on mount
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // Close on Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  const confirmed = confirmation === roomId;
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!confirmed) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`${API_BASE}/api/rooms/${encodeURIComponent(roomId)}`, {
+        method: "DELETE",
+        headers: authHeader(),
+      });
+
+      if (res.status === 204) {
+        onDeleted();
+        return;
+      }
+
+      if (res.status === 404) {
+        setError("Room not found — it may have already been deleted.");
+        return;
+      }
+
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      setError(body.error ?? `Unexpected error (${res.status})`);
+    } catch {
+      setError("Network error — could not reach server.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    /* Backdrop */
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+      data-testid="delete-room-modal"
+    >
+      <div className="bg-gray-800 rounded-lg shadow-xl w-full max-w-md mx-4 p-6">
+        <h2 className="text-lg font-semibold text-red-400 mb-2">
+          Delete room
+        </h2>
+        <p className="text-sm text-gray-400 mb-4">
+          This action is permanent. Type{" "}
+          <span className="font-mono text-gray-200">{roomId}</span> to confirm.
+        </p>
+
+        <form onSubmit={handleSubmit} noValidate>
+          <div className="mb-5">
+            <input
+              ref={inputRef}
+              type="text"
+              value={confirmation}
+              onChange={(e) => setConfirmation(e.target.value)}
+              placeholder={roomId}
+              className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded text-gray-100 placeholder-gray-500 text-sm focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent"
+              data-testid="delete-room-confirmation-input"
+            />
+          </div>
+
+          {error && (
+            <p
+              className="mb-4 text-sm text-red-400"
+              data-testid="delete-room-error"
+            >
+              {error}
+            </p>
+          )}
+
+          <div className="flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm text-gray-400 hover:text-gray-200 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting || !confirmed}
+              className="px-4 py-2 text-sm font-medium bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              data-testid="delete-room-submit"
+            >
+              {submitting ? "Deleting…" : "Delete room"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## MH-015: Delete Room

Implements hard-delete for rooms from both backend API and frontend UI.

### Backend

- `DELETE /api/rooms/:room_id` — removes the `workspace_rooms` row
- Returns `204 No Content` on success, `404` if room not found, `500` on DB error
- Route wired alongside existing `GET /api/rooms/{room_id}` in `main.rs`
- Unit tests: `delete_existing_room_returns_one`, `delete_nonexistent_room_returns_zero`

### Frontend

- `DeleteRoomModal` — confirmation dialog that requires typing the exact room name before the delete button activates (prevents accidental deletion)
- Trash icon (`🗑`) in room header, visible whenever a room is selected
- On success: modal closes, room removed from sidebar, room deselected
- Error states: 404 ("may have already been deleted"), 500 (generic), network error

### Tests

- 18 Playwright e2e tests in `hive-web/e2e/delete-room-mh015.spec.ts`
  - UI tests (mocked API): modal open/close, confirmation input gating, success flow, error handling
  - API tests (integration): 204 on existing room, 404 on non-existent, 401 without token, room absent from list after deletion
- 2 new Rust unit tests in `rooms.rs` (93 total, up from 91)

### Checklist

- [x] Backend: `DELETE /api/rooms/:room_id` with 204/404/500 responses
- [x] Frontend: `DeleteRoomModal` with confirmation, trash icon in header, deselect on delete
- [x] Tests: 18 Playwright e2e + 2 Rust unit tests
- [x] Clippy clean, no type suppressions
- [x] Verified docs/README are accurate after this change (no drift)

Closes #148