### PR TITLE
feat: GET /api/agents endpoint and AgentGrid auth (MH-025)

### DIFF
--- a/crates/hive-server/src/agents.rs
+++ b/crates/hive-server/src/agents.rs
@@ -1,0 +1,176 @@
+//! Agent list endpoint — MH-025.
+//!
+//! `GET /api/agents` returns the list of users registered in the room daemon.
+//! Health is reported as `healthy` for any user present in the daemon registry.
+//! Fields not tracked by the daemon (model, personality, pid) are returned as
+//! empty/zero defaults; callers should treat them as informational only.
+
+use std::sync::Arc;
+
+use axum::{extract::State, Json};
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::AppState;
+
+/// A single agent entry returned by `GET /api/agents`.
+#[derive(Debug, Serialize)]
+pub struct AgentInfo {
+    pub username: String,
+    pub health: &'static str,
+    pub model: String,
+    pub personality: String,
+    pub pid: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uptime: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub spawned_at: Option<String>,
+}
+
+/// Response envelope for `GET /api/agents`.
+#[derive(Debug, Serialize)]
+pub struct AgentsResponse {
+    pub agents: Vec<AgentInfo>,
+}
+
+/// Extract the daemon REST base URL from config.
+fn daemon_base(state: &AppState) -> String {
+    state
+        .config
+        .daemon
+        .ws_url
+        .replace("ws://", "http://")
+        .replace("wss://", "https://")
+}
+
+/// GET /api/agents — list all users registered in the room daemon.
+///
+/// Queries the daemon's `GET /api/users` endpoint and maps each username to an
+/// `AgentInfo`. If the daemon is unreachable the endpoint returns an empty list
+/// (graceful degradation — the frontend already handles this case).
+pub async fn list_agents(State(state): State<Arc<AppState>>) -> Json<AgentsResponse> {
+    let base = daemon_base(&state);
+    let url = format!("{base}/api/users");
+
+    let agents = match reqwest::Client::new()
+        .get(&url)
+        .timeout(std::time::Duration::from_secs(5))
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => match resp.json::<Value>().await {
+            Ok(body) => {
+                let usernames = body
+                    .get("users")
+                    .and_then(Value::as_array)
+                    .cloned()
+                    .unwrap_or_default();
+                usernames
+                    .into_iter()
+                    .filter_map(|v| v.as_str().map(str::to_owned))
+                    .map(|username| AgentInfo {
+                        username,
+                        health: "healthy",
+                        model: String::new(),
+                        personality: String::new(),
+                        pid: 0,
+                        status: None,
+                        uptime: None,
+                        spawned_at: None,
+                    })
+                    .collect()
+            }
+            Err(_) => vec![],
+        },
+        _ => vec![],
+    };
+
+    Json(AgentsResponse { agents })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_agent(username: &str) -> AgentInfo {
+        AgentInfo {
+            username: username.to_owned(),
+            health: "healthy",
+            model: String::new(),
+            personality: String::new(),
+            pid: 0,
+            status: None,
+            uptime: None,
+            spawned_at: None,
+        }
+    }
+
+    #[test]
+    fn agent_info_serializes_username_and_health() {
+        let agent = make_agent("alice");
+        let json = serde_json::to_value(&agent).unwrap();
+        assert_eq!(json["username"], "alice");
+        assert_eq!(json["health"], "healthy");
+    }
+
+    #[test]
+    fn agent_info_serializes_model_and_personality() {
+        let agent = make_agent("bob");
+        let json = serde_json::to_value(&agent).unwrap();
+        assert_eq!(json["model"], "");
+        assert_eq!(json["personality"], "");
+    }
+
+    #[test]
+    fn agent_info_serializes_pid_zero() {
+        let agent = make_agent("carol");
+        let json = serde_json::to_value(&agent).unwrap();
+        assert_eq!(json["pid"], 0);
+    }
+
+    #[test]
+    fn agent_info_omits_optional_fields_when_none() {
+        let agent = make_agent("dave");
+        let json = serde_json::to_value(&agent).unwrap();
+        assert!(json.get("status").is_none());
+        assert!(json.get("uptime").is_none());
+        assert!(json.get("spawned_at").is_none());
+    }
+
+    #[test]
+    fn agent_info_includes_optional_status_when_set() {
+        let agent = AgentInfo {
+            username: "eve".to_owned(),
+            health: "healthy",
+            model: String::new(),
+            personality: String::new(),
+            pid: 0,
+            status: Some("working on PR #42".to_owned()),
+            uptime: None,
+            spawned_at: None,
+        };
+        let json = serde_json::to_value(&agent).unwrap();
+        assert_eq!(json["status"], "working on PR #42");
+    }
+
+    #[test]
+    fn agents_response_wraps_list() {
+        let resp = AgentsResponse {
+            agents: vec![make_agent("alice"), make_agent("bob")],
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        let arr = json["agents"].as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["username"], "alice");
+        assert_eq!(arr[1]["username"], "bob");
+    }
+
+    #[test]
+    fn agents_response_empty_list() {
+        let resp = AgentsResponse { agents: vec![] };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["agents"].as_array().unwrap().len(), 0);
+    }
+}

--- a/crates/hive-server/src/main.rs
+++ b/crates/hive-server/src/main.rs
@@ -1,4 +1,5 @@
 pub mod admin;
+pub mod agents;
 pub mod auth;
 mod config;
 pub mod daemon;
@@ -157,6 +158,7 @@ async fn main() {
             get(settings::get_settings).patch(settings::patch_settings),
         )
         .route("/api/settings/history", get(settings::get_settings_history))
+        .route("/api/agents", get(agents::list_agents))
         .route("/ws/{room_id}", get(ws_relay::ws_handler))
         .layer(middleware::from_fn_with_state(
             Arc::clone(&state),

--- a/hive-web/e2e/mh025-agent-list.spec.ts
+++ b/hive-web/e2e/mh025-agent-list.spec.ts
@@ -1,0 +1,231 @@
+/**
+ * Playwright e2e tests for MH-025 Agent List (AgentGrid component).
+ *
+ * All tests use page.route() to mock /api/agents — no live backend required.
+ * Auth token is injected via localStorage.
+ */
+import { test, expect } from '@playwright/test';
+
+/** Fabricate a minimal JWT so RequireAuth passes without a real server. */
+function makeToken(data: {
+  sub: string;
+  username: string;
+  role: string;
+  exp?: number;
+}): string {
+  const header = Buffer.from('{"alg":"HS256","typ":"JWT"}').toString('base64url');
+  const payload = Buffer.from(
+    JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 3600, ...data }),
+  ).toString('base64url');
+  return `${header}.${payload}.fake-signature`;
+}
+
+const TOKEN = makeToken({ sub: '1', username: 'tester', role: 'admin' });
+
+/** Inject auth token and stub health + setup endpoints so the app loads. */
+async function setupPage(page: import('@playwright/test').Page) {
+  await page.addInitScript((tok) => {
+    localStorage.setItem('hive-auth-token', tok);
+  }, TOKEN);
+
+  await page.route('**/api/health', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        status: 'ok',
+        version: '0.1.0',
+        uptime_secs: 120,
+        daemon_connected: true,
+        daemon_url: 'ws://127.0.0.1:4200',
+      }),
+    }),
+  );
+
+  await page.route('**/api/setup/status', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ complete: true }),
+    }),
+  );
+}
+
+test.describe('MH-025: Agent List', () => {
+  test('agent-grid data-testid is present on page load', async ({ page }) => {
+    await setupPage(page);
+
+    await page.route('**/api/agents', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ agents: [] }),
+      }),
+    );
+
+    await page.goto('/');
+    await expect(page.locator('[data-testid="agent-grid"]')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('renders one agent-card per agent returned by the API', async ({ page }) => {
+    await setupPage(page);
+
+    await page.route('**/api/agents', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          agents: [
+            { username: 'alice', health: 'healthy' },
+            { username: 'bob', health: 'warning' },
+            { username: 'carol', health: 'stale' },
+          ],
+        }),
+      }),
+    );
+
+    await page.goto('/');
+    await expect(page.locator('[data-testid="agent-card"]').first()).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.locator('[data-testid="agent-card"]')).toHaveCount(3);
+  });
+
+  test('agent card displays username', async ({ page }) => {
+    await setupPage(page);
+
+    await page.route('**/api/agents', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          agents: [{ username: 'r2d2', health: 'healthy' }],
+        }),
+      }),
+    );
+
+    await page.goto('/');
+    await expect(page.getByText('r2d2')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('shows empty state when no agents are registered', async ({ page }) => {
+    await setupPage(page);
+
+    await page.route('**/api/agents', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ agents: [] }),
+      }),
+    );
+
+    await page.goto('/');
+    await expect(page.getByText(/no agents connected/i)).toBeVisible({ timeout: 10000 });
+  });
+
+  test('shows error banner when API returns 500', async ({ page }) => {
+    await setupPage(page);
+
+    await page.route('**/api/agents', (route) =>
+      route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 'internal', message: 'Internal server error' }),
+      }),
+    );
+
+    await page.goto('/');
+    await expect(page.getByText(/cannot connect/i)).toBeVisible({ timeout: 10000 });
+  });
+
+  test('shows error banner when network request fails', async ({ page }) => {
+    await setupPage(page);
+
+    await page.route('**/api/agents', (route) => route.abort());
+
+    await page.goto('/');
+    await expect(page.getByText(/cannot connect/i)).toBeVisible({ timeout: 10000 });
+  });
+
+  test('summary bar shows correct plural agent count', async ({ page }) => {
+    await setupPage(page);
+
+    await page.route('**/api/agents', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          agents: [
+            { username: 'alice', health: 'healthy' },
+            { username: 'bob', health: 'healthy' },
+            { username: 'carol', health: 'stale' },
+          ],
+        }),
+      }),
+    );
+
+    await page.goto('/');
+    await expect(page.getByText('3 agents')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('summary bar shows singular "agent" for count of 1', async ({ page }) => {
+    await setupPage(page);
+
+    await page.route('**/api/agents', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          agents: [{ username: 'solo', health: 'healthy' }],
+        }),
+      }),
+    );
+
+    await page.goto('/');
+    await expect(page.getByText('1 agent')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('1 agents')).not.toBeVisible();
+  });
+
+  test('agent card displays status field when present', async ({ page }) => {
+    await setupPage(page);
+
+    await page.route('**/api/agents', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          agents: [
+            {
+              username: 'worker',
+              health: 'healthy',
+              status: 'implementing PR #42',
+            },
+          ],
+        }),
+      }),
+    );
+
+    await page.goto('/');
+    await expect(page.getByText('implementing PR #42')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('GET /api/agents request includes Authorization Bearer header', async ({ page }) => {
+    await setupPage(page);
+
+    const authHeaders: string[] = [];
+    await page.route('**/api/agents', (route) => {
+      const authHeader = route.request().headers()['authorization'];
+      if (authHeader) authHeaders.push(authHeader);
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ agents: [] }),
+      });
+    });
+
+    await page.goto('/');
+    await page.waitForTimeout(1500);
+    expect(authHeaders.length).toBeGreaterThan(0);
+    expect(authHeaders[0]).toMatch(/^Bearer /);
+  });
+});

--- a/hive-web/src/components/AgentGrid.tsx
+++ b/hive-web/src/components/AgentGrid.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
+import { apiFetch } from '../lib/apiError';
+import { authHeader } from '../lib/auth';
 import { EmptyState } from './EmptyState';
 
 const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:3000';
@@ -6,13 +8,22 @@ const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 /** Agent data from the /api/agents endpoint. */
 export interface Agent {
   username: string;
-  personality: string;
-  model: string;
-  pid: number;
+  /** Health of the agent as reported by the daemon. */
   health: 'healthy' | 'warning' | 'stale' | 'exited';
+  /** Model name — may be empty if not tracked by the daemon. */
+  model?: string;
+  /** Personality label — may be empty if not tracked by the daemon. */
+  personality?: string;
+  /** PID — may be 0 if not tracked by the daemon. */
+  pid?: number;
   status?: string;
   uptime?: string;
   spawned_at?: string;
+}
+
+/** Response envelope from GET /api/agents. */
+interface AgentsResponse {
+  agents: Agent[];
 }
 
 /** Health status indicator with color coding. */
@@ -42,20 +53,26 @@ function AgentCard({ agent }: { agent: Agent }) {
         <span className="text-lg">🤖</span>
         <div className="min-w-0 flex-1">
           <div className="font-medium text-gray-100 truncate">{agent.username}</div>
-          <div className="text-xs text-gray-400">{agent.personality}</div>
+          {agent.personality && (
+            <div className="text-xs text-gray-400">{agent.personality}</div>
+          )}
         </div>
         <HealthDot health={agent.health} />
       </div>
 
       <div className="space-y-1 text-xs text-gray-400">
-        <div className="flex justify-between">
-          <span>Model</span>
-          <span className="text-gray-300">{agent.model}</span>
-        </div>
-        <div className="flex justify-between">
-          <span>PID</span>
-          <span className="text-gray-300">{agent.pid}</span>
-        </div>
+        {agent.model && (
+          <div className="flex justify-between">
+            <span>Model</span>
+            <span className="text-gray-300">{agent.model}</span>
+          </div>
+        )}
+        {typeof agent.pid === 'number' && agent.pid > 0 && (
+          <div className="flex justify-between">
+            <span>PID</span>
+            <span className="text-gray-300">{agent.pid}</span>
+          </div>
+        )}
         {agent.uptime && (
           <div className="flex justify-between">
             <span>Uptime</span>
@@ -81,17 +98,11 @@ export function AgentGrid() {
 
   const fetchAgents = useCallback(async () => {
     try {
-      const res = await fetch(`${API_BASE}/api/agents`);
-      if (res.ok) {
-        const data = await res.json();
-        setAgents(data.agents || data || []);
-        setError(null);
-      } else if (res.status === 501) {
-        setAgents([]);
-        setError('Agent management not yet implemented');
-      } else {
-        setError(`Failed to fetch agents: ${res.status}`);
-      }
+      const data = await apiFetch<AgentsResponse>(`${API_BASE}/api/agents`, {
+        headers: authHeader(),
+      });
+      setAgents(data.agents ?? []);
+      setError(null);
     } catch {
       setAgents([]);
       setError('Cannot connect to hive-server');


### PR DESCRIPTION
## Summary
- Add `GET /api/agents` endpoint in `agents.rs` that proxies to the room daemon's `GET /api/users`, mapping each registered username to an `AgentInfo` with `health: "healthy"` and empty defaults for daemon-untracked fields (`model`, `personality`, `pid`). Protected by `auth_middleware`. Gracefully returns empty list when daemon is unreachable.
- Register `pub mod agents` and `/api/agents` route in `main.rs`.
- Update `AgentGrid.tsx` to use `apiFetch` + `authHeader()` instead of bare `fetch` (key invariant: `apiFetch` for all API calls). Make `model`, `personality`, `pid` optional in `Agent` interface.
- Add 9 Playwright e2e tests in `mh025-agent-list.spec.ts`.
- Add 7 unit tests in `agents.rs`.

## Test plan
- [x] `cargo test -p hive-server` passes (98 tests)
- [x] `node_modules/.bin/tsc --noEmit` passes
- [x] `pnpm build` succeeds
- [x] `pnpm exec eslint src/` clean
- [x] Playwright tests added (`hive-web/e2e/mh025-agent-list.spec.ts`, 9 tests)

## Checklist
- [x] CHANGELOG entry added under [Unreleased]
- [x] Verified docs and README are accurate after this change (no drift)
- [x] Test count did not decrease (91 → 98 Rust tests; 9 new Playwright tests)

## CHANGELOG
### Added
- `GET /api/agents` endpoint returning all users registered in the room daemon as agent entries with health status (MH-025)
- `AgentGrid` now authenticates requests with `Authorization: Bearer` header via `apiFetch` + `authHeader()` (key invariant compliance)

Closes #821