### PR TITLE
fix(hive-web): include tests/e2e/ in playwright testMatch (#173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `playwright.config.ts` now uses `testMatch` covering both `./e2e/` and `./tests/e2e/` — 40 tests in `tests/e2e/` were previously orphaned and never run by CI (#173)
+
 ### Added
 - `GET /api/users/me` endpoint — returns username, role, and ID from JWT claims (MH-011)
 - Profile page at `/profile` — displays avatar initials, username, role badge, and user ID

--- a/hive-web/playwright.config.ts
+++ b/hive-web/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './e2e',
+  testMatch: ['./e2e/**/*.spec.ts', './tests/e2e/**/*.spec.ts'],
   timeout: 30000,
   retries: 0,
   use: {


### PR DESCRIPTION
## Summary
- `playwright.config.ts` was pointing `testDir` at `./e2e/` only — 40 tests in `tests/e2e/` were never discovered by CI
- Replace `testDir` with `testMatch` array covering both `./e2e/**/*.spec.ts` and `./tests/e2e/**/*.spec.ts`
- One-line config change; no test files modified

## Test plan
- [ ] `npx playwright test --list` now shows tests from both `e2e/` and `tests/e2e/`
- [ ] CI Playwright job picks up all suites
- [ ] Verified docs/README are accurate after this change (no drift)

Closes #173