### PR TITLE
test(config): add unit tests for load_config() — closes #176

### DIFF
--- a/crates/hive-server/src/config.rs
+++ b/crates/hive-server/src/config.rs
@@ -83,3 +83,123 @@ pub fn load_config(path: &Path) -> HiveConfig {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+
+    /// Serializes env-var tests to prevent inter-test pollution.
+    ///
+    /// `set_var`/`remove_var` are unsafe (not thread-safe) since Rust 1.84.
+    /// All tests that mutate env vars must hold this lock for their duration.
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn load_config_parses_valid_toml() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("hive.toml");
+        std::fs::write(
+            &path,
+            r#"
+[server]
+host = "0.0.0.0"
+port = 8080
+data_dir = "/tmp/hive-test-data"
+
+[daemon]
+socket_path = "/tmp/custom.sock"
+ws_url = "ws://127.0.0.1:9000"
+"#,
+        )
+        .unwrap();
+
+        let cfg = load_config(&path);
+
+        assert_eq!(cfg.server.host, "0.0.0.0");
+        assert_eq!(cfg.server.port, 8080);
+        assert_eq!(cfg.server.data_dir, "/tmp/hive-test-data");
+        assert_eq!(cfg.daemon.socket_path, PathBuf::from("/tmp/custom.sock"));
+        assert_eq!(cfg.daemon.ws_url, "ws://127.0.0.1:9000");
+    }
+
+    #[test]
+    fn load_config_missing_file_returns_defaults() {
+        let cfg = load_config(Path::new("/nonexistent/no-such-file/hive.toml"));
+
+        // Defaults are env-dependent; just verify the struct is well-formed.
+        assert!(!cfg.daemon.ws_url.is_empty());
+        assert_eq!(cfg.daemon.socket_path, PathBuf::from("/tmp/roomd.sock"));
+    }
+
+    #[test]
+    fn load_config_invalid_toml_returns_defaults() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("hive.toml");
+        std::fs::write(&path, "this is ][ not [valid toml at all").unwrap();
+
+        let cfg = load_config(&path);
+
+        assert_eq!(cfg.daemon.socket_path, PathBuf::from("/tmp/roomd.sock"));
+        assert_eq!(cfg.daemon.ws_url, "ws://127.0.0.1:4200");
+    }
+
+    #[test]
+    fn server_config_default_reads_env_vars() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        // SAFETY: single-threaded access guaranteed by ENV_MUTEX.
+        unsafe {
+            std::env::set_var("HIVE_HOST", "10.0.0.1");
+            std::env::set_var("HIVE_PORT", "9999");
+            std::env::set_var("HIVE_DATA_DIR", "/custom/data");
+        }
+        let cfg = ServerConfig::default();
+        // SAFETY: same lock held.
+        unsafe {
+            std::env::remove_var("HIVE_HOST");
+            std::env::remove_var("HIVE_PORT");
+            std::env::remove_var("HIVE_DATA_DIR");
+        }
+
+        assert_eq!(cfg.host, "10.0.0.1");
+        assert_eq!(cfg.port, 9999);
+        assert_eq!(cfg.data_dir, "/custom/data");
+    }
+
+    #[test]
+    fn server_config_default_hardcoded_fallbacks() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        // SAFETY: single-threaded access guaranteed by ENV_MUTEX.
+        unsafe {
+            std::env::remove_var("HIVE_HOST");
+            std::env::remove_var("HIVE_PORT");
+            std::env::remove_var("HIVE_DATA_DIR");
+        }
+        let cfg = ServerConfig::default();
+
+        assert_eq!(cfg.host, "127.0.0.1");
+        assert_eq!(cfg.port, 3000);
+        assert!(
+            cfg.data_dir.ends_with("/.hive/data"),
+            "expected data_dir to end with /.hive/data, got: {}",
+            cfg.data_dir
+        );
+    }
+
+    #[test]
+    fn server_config_invalid_port_env_uses_default() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        unsafe {
+            std::env::set_var("HIVE_PORT", "not-a-number");
+            std::env::remove_var("HIVE_HOST");
+            std::env::remove_var("HIVE_DATA_DIR");
+        }
+        let cfg = ServerConfig::default();
+        unsafe {
+            std::env::remove_var("HIVE_PORT");
+        }
+
+        assert_eq!(cfg.port, 3000, "invalid HIVE_PORT should fall back to 3000");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `#[cfg(test)]` block to `config.rs` with 6 tests covering all `load_config()` and `ServerConfig::default()` paths
- Tests: valid TOML parse, missing file fallback, invalid TOML fallback, env var reading (HIVE_HOST/PORT/DATA_DIR), hardcoded fallback defaults, invalid port env fallback
- Static `Mutex` serializes env var tests (safe for parallel test runner; `set_var`/`remove_var` unsafe since Rust 1.84)
- Uses existing `tempfile` dev-dependency — no new deps

## Test plan
- [ ] `cargo test -p hive-server config` — all 6 config tests pass
- [ ] `cargo clippy -p hive-server -- -D warnings` — clean
- [ ] `cargo fmt -p hive-server -- --check` — clean

Closes #176