### PR TITLE
ci: add Playwright e2e test job to CI workflow (#185)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Start hive-server
         run: |
           mkdir -p /tmp/hive-data
-          HIVE_JWT_SECRET=ci-test-secret \
+          HIVE_JWT_SECRET=ci-test-secret-for-playwright-e2e-tests-only \
           HIVE_ADMIN_USER=admin \
           HIVE_ADMIN_PASSWORD=admin-password \
           HIVE_DATA_DIR=/tmp/hive-data \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,8 @@ jobs:
         run: cd hive-web && pnpm exec playwright test
         env:
           HIVE_API_URL: http://localhost:3000
+          HIVE_ADMIN_USER: admin
+          HIVE_ADMIN_PASSWORD: admin-password
 
       - name: Upload Playwright report
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,13 +90,8 @@ jobs:
           echo "hive-server did not start in 30s" >&2
           exit 1
 
-      - name: List Playwright tests
-        run: cd hive-web && pnpm exec playwright test --list || true
-        env:
-          HIVE_API_URL: http://localhost:3000
-
       - name: Run Playwright tests
-        run: cd hive-web && pnpm exec playwright test e2e/ tests/e2e/
+        run: cd hive-web && pnpm exec playwright test
         env:
           HIVE_API_URL: http://localhost:3000
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
         run: cd hive-web && pnpm install --frozen-lockfile
       - name: Install Playwright browsers
         run: cd hive-web && pnpm exec playwright install chromium --with-deps
+      - name: Build frontend
+        run: cd hive-web && pnpm build
 
       - name: Start hive-server
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,13 @@ jobs:
           echo "hive-server did not start in 30s" >&2
           exit 1
 
+      - name: List Playwright tests
+        run: cd hive-web && pnpm exec playwright test --list || true
+        env:
+          HIVE_API_URL: http://localhost:3000
+
       - name: Run Playwright tests
-        run: cd hive-web && pnpm exec playwright test
+        run: cd hive-web && pnpm exec playwright test e2e/ tests/e2e/
         env:
           HIVE_API_URL: http://localhost:3000
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,60 @@ jobs:
         run: cd hive-web && pnpm build
       - name: Lint
         run: cd hive-web && pnpm exec eslint src/
+
+  e2e:
+    name: E2E (Playwright)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build hive-server
+        run: cargo build -p hive-server
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: hive-web/pnpm-lock.yaml
+      - name: Install frontend deps
+        run: cd hive-web && pnpm install --frozen-lockfile
+      - name: Install Playwright browsers
+        run: cd hive-web && pnpm exec playwright install chromium --with-deps
+
+      - name: Start hive-server
+        run: |
+          mkdir -p /tmp/hive-data
+          HIVE_JWT_SECRET=ci-test-secret \
+          HIVE_ADMIN_USER=admin \
+          HIVE_ADMIN_PASSWORD=admin-password \
+          HIVE_DATA_DIR=/tmp/hive-data \
+          ./target/debug/hive &
+          echo $! > /tmp/hive-server.pid
+
+      - name: Wait for hive-server
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3000/api/health > /dev/null; then
+              echo "hive-server ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "hive-server did not start in 30s" >&2
+          exit 1
+
+      - name: Run Playwright tests
+        run: cd hive-web && pnpm exec playwright test
+        env:
+          HIVE_API_URL: http://localhost:3000
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: hive-web/playwright-report/

--- a/hive-web/playwright.config.ts
+++ b/hive-web/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testMatch: ['./e2e/**/*.spec.ts', './tests/e2e/**/*.spec.ts'],
+  testMatch: ['e2e/**/*.spec.ts', 'tests/e2e/**/*.spec.ts'],
   timeout: 30000,
   retries: 0,
   use: {

--- a/hive-web/playwright.config.ts
+++ b/hive-web/playwright.config.ts
@@ -9,10 +9,10 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
   webServer: {
-    command: 'pnpm dev --host 0.0.0.0 --port 5173',
+    command: 'pnpm preview --host 0.0.0.0 --port 5173',
     port: 5173,
     reuseExistingServer: true,
-    timeout: 30000,
+    timeout: 60000,
   },
   projects: [
     {


### PR DESCRIPTION
## Summary

- Adds an `e2e` job to `.github/workflows/ci.yml` that runs the full Playwright test suite on every PR
- Builds `hive-server` from source, starts it in the background, waits for `/api/health`, then runs `pnpm exec playwright test`
- Uploads `playwright-report` as a CI artifact when tests fail for easier debugging
- Room daemon is not started; `mh022` ws_relay tests accept `502` as valid when daemon is unavailable

## How it works

1. **Build** — `cargo build -p hive-server` produces `./target/debug/hive`
2. **Frontend deps** — `pnpm install --frozen-lockfile` + `playwright install chromium --with-deps`
3. **Start server** — launches hive-server with `HIVE_JWT_SECRET`, `HIVE_ADMIN_USER`, `HIVE_ADMIN_PASSWORD`, `HIVE_DATA_DIR=/tmp/hive-data`
4. **Health wait** — 30-second curl retry loop against `http://localhost:3000/api/health`
5. **Tests** — `pnpm exec playwright test` with `HIVE_API_URL=http://localhost:3000`; playwright.config.ts auto-starts the frontend dev server via `webServer`
6. **Artifact** — uploads `hive-web/playwright-report/` on failure

## Test plan

- [ ] CI e2e job runs and completes on this PR
- [ ] Playwright tests pass (or known failures surfaced with report artifact)

Closes #185
