### PR TITLE
fix(hive-server): replace constant-value assertions with behavior tests (#176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - `playwright.config.ts` now uses `testMatch` covering both `./e2e/` and `./tests/e2e/` — 40 tests in `tests/e2e/` were previously orphaned and never run by CI (#173)
+- Replaced constant-value test assertions in `ws_relay.rs` and `rooms.rs` with behavior assertions; extracted `validate_description_len` helper from inline handler guard (#176)
 
 ### Added
 - `GET /api/users/me` endpoint — returns username, role, and ID from JWT claims (MH-011)

--- a/crates/hive-server/src/rooms.rs
+++ b/crates/hive-server/src/rooms.rs
@@ -91,6 +91,14 @@ fn validate_room_name(name: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Validate room description length: max 280 characters.
+fn validate_description_len(desc: &str) -> Result<(), &'static str> {
+    if desc.len() > 280 {
+        return Err("description must be 280 characters or fewer");
+    }
+    Ok(())
+}
+
 /// Derive a room ID from a name: lowercase, spaces → hyphens.
 ///
 /// The caller is responsible for ensuring uniqueness (appending a suffix if
@@ -322,10 +330,10 @@ pub async fn patch_room(
 
     // Validate description length if provided.
     if let Some(ref desc) = body.description {
-        if desc.len() > 280 {
+        if let Err(msg) = validate_description_len(desc) {
             return (
                 StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({"error": "description must be 280 characters or fewer"})),
+                Json(serde_json::json!({"error": msg})),
             )
                 .into_response();
         }
@@ -867,11 +875,10 @@ mod tests {
     }
 
     #[test]
-    fn patch_room_description_too_long_rejected() {
-        let long_desc = "a".repeat(281);
-        // Validation is in the HTTP handler; test the length boundary directly.
-        assert!(long_desc.len() > 280);
-        assert!("a".repeat(280).len() <= 280);
+    fn description_length_validation_enforces_280_char_limit() {
+        assert!(validate_description_len(&"a".repeat(281)).is_err());
+        assert!(validate_description_len(&"a".repeat(280)).is_ok());
+        assert!(validate_description_len("").is_ok());
     }
 
     #[test]

--- a/crates/hive-server/src/ws_relay.rs
+++ b/crates/hive-server/src/ws_relay.rs
@@ -511,14 +511,33 @@ mod tests {
         }
     }
 
-    #[test]
-    fn connect_timeout_is_two_seconds() {
-        assert_eq!(CONNECT_TIMEOUT, Duration::from_secs(2));
+    #[tokio::test]
+    async fn connect_to_refused_address_returns_connection_error() {
+        // Port 1 on loopback is reserved and immediately refused by the OS,
+        // so this exercises the "connection failed" error path without waiting
+        // for the full CONNECT_TIMEOUT.
+        let result = connect_with_timeout("ws://127.0.0.1:1").await;
+        assert!(result.is_err(), "expected Err for refused port");
+        let msg = result.unwrap_err();
+        assert!(
+            msg.starts_with("connection"),
+            "error should describe a connection problem, got: {msg}"
+        );
     }
 
-    #[test]
-    fn max_reconnect_attempts_is_five() {
-        assert_eq!(MAX_RECONNECT_ATTEMPTS, 5);
+    #[tokio::test]
+    async fn try_reconnect_returns_none_after_all_attempts_fail() {
+        // Use a tiny max_backoff so the 5 attempts complete quickly.
+        let config = DaemonWsConfig {
+            max_backoff: Duration::from_millis(1),
+            ..DaemonWsConfig::default()
+        };
+        // Port 1 on loopback refuses immediately, so all attempts exhaust fast.
+        let result = try_reconnect("ws://127.0.0.1:1", &config, None).await;
+        assert!(
+            result.is_none(),
+            "expected None after all reconnection attempts fail"
+        );
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `ws_relay.rs`: replaced two constant-value `assert_eq` tests with `#[tokio::test]` behavior tests that exercise `connect_with_timeout` and `try_reconnect` against a refused port
- `rooms.rs`: extracted inline `desc.len() > 280` guard to `validate_description_len` helper; replaced trivially-true math assertions with boundary tests calling the helper
- 171 tests pass (was 165 before these changes)
- Rebased onto latest master (includes r2d2's reconnect_daemon refactor)

Supersedes #188 (same changes, rebased).

## Test plan
- [ ] `cargo test -p hive-server` — 171 tests pass
- [ ] `cargo clippy -p hive-server -- -D warnings` clean
- [ ] `cargo fmt -- --check` clean
- [ ] Verified docs/README are accurate after this change (no drift)

Closes #176