### PR TITLE
test(hive-web): delete dead OAuth stubs and duplicate room-create API tests

### DIFF
--- a/hive-web/e2e/auth.spec.ts
+++ b/hive-web/e2e/auth.spec.ts
@@ -2,32 +2,6 @@ import { test, expect } from '@playwright/test';
 
 const API_URL = process.env.HIVE_API_URL || 'http://localhost:3000';
 
-test.describe('BE-008: GitHub OAuth Authentication', () => {
-  test('GET /api/auth/login redirects to GitHub OAuth or returns 404 (not implemented)', async ({ request }) => {
-    const response = await request.get(`${API_URL}/api/auth/login`, {
-      maxRedirects: 0,
-    });
-    // Should redirect (302), return auth config, or 404 (not implemented yet)
-    expect([200, 302, 401, 404]).toContain(response.status());
-  });
-
-  test('unauthenticated request to protected endpoint returns 401 or 404', async ({ request }) => {
-    const response = await request.get(`${API_URL}/api/workspaces`);
-    expect([401, 404]).toContain(response.status());
-    if (response.status() === 401) {
-      const body = await response.json();
-      expect(body.error).toBeDefined();
-    }
-  });
-
-  test('invalid token returns 401 or 404', async ({ request }) => {
-    const response = await request.get(`${API_URL}/api/workspaces`, {
-      headers: { Authorization: 'Bearer invalid-token-123' },
-    });
-    expect([401, 404]).toContain(response.status());
-  });
-});
-
 test.describe('BE-009: Session Management', () => {
   test('health endpoint works without auth', async ({ request }) => {
     const response = await request.get(`${API_URL}/api/health`);

--- a/hive-web/e2e/create-room-mh014.spec.ts
+++ b/hive-web/e2e/create-room-mh014.spec.ts
@@ -7,10 +7,6 @@
 
 import { test, expect } from '@playwright/test';
 
-const API_URL = process.env.HIVE_API_URL || 'http://localhost:3000';
-const ADMIN_USER = process.env.HIVE_ADMIN_USER || 'admin';
-const ADMIN_PASSWORD = process.env.HIVE_ADMIN_PASSWORD || 'test-password';
-
 const MOCK_TOKEN = 'mock-jwt-token-mh014';
 
 // ---------------------------------------------------------------------------
@@ -197,44 +193,3 @@ test.describe('MH-014: create room — error handling', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// API tests (requires running backend)
-// ---------------------------------------------------------------------------
-
-test.describe('MH-014: POST /api/rooms — API validation', () => {
-  async function getToken(request: Parameters<Parameters<typeof test>[1]>[0]['request']): Promise<string> {
-    const res = await request.post(`${API_URL}/api/auth/login`, {
-      data: { username: ADMIN_USER, password: ADMIN_PASSWORD },
-    });
-    expect(res.status()).toBe(200);
-    const body = await res.json();
-    return body.token as string;
-  }
-
-  test('POST /api/rooms returns 201 with valid name', async ({ request }) => {
-    const token = await getToken(request);
-    const res = await request.post(`${API_URL}/api/rooms`, {
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-      data: { name: `ui-test-${Date.now()}` },
-    });
-    expect(res.status()).toBe(201);
-    const body = await res.json();
-    expect(typeof body.id).toBe('string');
-  });
-
-  test('POST /api/rooms returns 400 for spaces in name', async ({ request }) => {
-    const token = await getToken(request);
-    const res = await request.post(`${API_URL}/api/rooms`, {
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-      data: { name: 'has space' },
-    });
-    expect(res.status()).toBe(400);
-  });
-
-  test('POST /api/rooms returns 401 without token', async ({ request }) => {
-    const res = await request.post(`${API_URL}/api/rooms`, {
-      data: { name: 'no-auth' },
-    });
-    expect(res.status()).toBe(401);
-  });
-});


### PR DESCRIPTION
## Summary
- **auth.spec.ts**: remove `BE-008: GitHub OAuth Authentication` describe block (3 stub tests that accepted any response code — zero assertion value). Keep `BE-009` health test.
- **create-room-mh014.spec.ts**: remove `MH-014: POST /api/rooms — API validation` describe block (3 tests duplicating `rooms-mh016.spec.ts` POST coverage). Remove now-unused `API_URL`, `ADMIN_USER`, `ADMIN_PASSWORD` constants. All remaining tests are UI/mock tests.

## Test plan
- [ ] `tsc --noEmit` — clean
- [ ] No test logic removed that wasn't covered elsewhere (rooms-mh016.spec.ts has full POST /api/rooms API coverage)

## Docs accuracy
- [ ] Verified docs/README are accurate after this change (no drift)

Closes #177