### PR TITLE
fix(hive-web): remove ./ prefix from playwright testMatch patterns

### DIFF
--- a/hive-web/playwright.config.ts
+++ b/hive-web/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testMatch: ['./e2e/**/*.spec.ts', './tests/e2e/**/*.spec.ts'],
+  testMatch: ['e2e/**/*.spec.ts', 'tests/e2e/**/*.spec.ts'],
   timeout: 30000,
   retries: 0,
   use: {


### PR DESCRIPTION
## Summary
- Playwright 1.58 does not resolve `testMatch` patterns with a `./` prefix correctly against absolute paths in CI, causing 0 tests discovered
- Remove the prefix: `'./e2e/**/*.spec.ts'` → `'e2e/**/*.spec.ts'` and `'./tests/e2e/**/*.spec.ts'` → `'tests/e2e/**/*.spec.ts'`
- Regression introduced by #181 (my PR)

## Test plan
- [ ] `pnpm exec playwright test --list` discovers tests from both `e2e/` and `tests/e2e/`
- [ ] CI e2e job (PR #189) picks up tests after this merges
- [ ] Verified docs/README are accurate after this change (no drift)