### PR TITLE
test(hive-web): add 401 to expected status codes in unauthenticated e2e API tests

### DIFF
--- a/hive-web/e2e/agents.spec.ts
+++ b/hive-web/e2e/agents.spec.ts
@@ -10,8 +10,8 @@ test.describe('BE-012: Agent Spawn', () => {
         room_id: 'test-room',
       },
     });
-    // 201 (spawned), 400 (bad request), or 501 (not yet implemented)
-    expect([201, 400, 404, 501]).toContain(response.status());
+    // 201 (spawned), 400 (bad request), 401 (unauthorized), or 501 (not yet implemented)
+    expect([201, 400, 401, 404, 501]).toContain(response.status());
   });
 
   test('GET /api/agents returns agent list or 404/501', async ({ request }) => {
@@ -25,20 +25,20 @@ test.describe('BE-012: Agent Spawn', () => {
 
   test('DELETE /api/agents/:id returns result or 501', async ({ request }) => {
     const response = await request.delete(`${API_URL}/api/agents/nonexistent-agent`);
-    expect([200, 404, 501]).toContain(response.status());
+    expect([200, 401, 404, 501]).toContain(response.status());
   });
 });
 
 test.describe('BE-013: Agent Health Monitoring', () => {
   test('GET /api/agents/health returns health status or 404/501', async ({ request }) => {
     const response = await request.get(`${API_URL}/api/agents/health`);
-    expect([200, 404, 501]).toContain(response.status());
+    expect([200, 401, 404, 501]).toContain(response.status());
   });
 });
 
 test.describe('BE-015: Agent Logs', () => {
   test('GET /api/agents/:id/logs returns logs or 501', async ({ request }) => {
     const response = await request.get(`${API_URL}/api/agents/test-agent/logs`);
-    expect([200, 404, 501]).toContain(response.status());
+    expect([200, 401, 404, 501]).toContain(response.status());
   });
 });

--- a/hive-web/e2e/ws-relay.spec.ts
+++ b/hive-web/e2e/ws-relay.spec.ts
@@ -68,7 +68,7 @@ test.describe('BE-003: WebSocket relay', () => {
     const result = await tryWsUpgrade(wsUrl('/ws/test-room'));
     // 'upgraded' → server accepted the WS handshake (101)
     // 400/502/503 → server declined upgrade for a known reason (daemon unavailable, etc.)
-    const valid: Array<WsResult['statusOrUpgraded']> = ['upgraded', 400, 502, 503];
+    const valid: Array<WsResult['statusOrUpgraded']> = ['upgraded', 400, 401, 502, 503];
     expect(valid).toContain(result.statusOrUpgraded);
   });
 
@@ -81,7 +81,7 @@ test.describe('BE-003: WebSocket relay', () => {
   test('WS endpoint for nonexistent room accepts upgrade or returns defined error', async () => {
     const result = await tryWsUpgrade(wsUrl('/ws/nonexistent-room-fix099'));
     // Same valid set — server should not return an unexpected status
-    const valid: Array<WsResult['statusOrUpgraded']> = ['upgraded', 400, 404, 502, 503];
+    const valid: Array<WsResult['statusOrUpgraded']> = ['upgraded', 400, 401, 404, 502, 503];
     expect(valid).toContain(result.statusOrUpgraded);
   });
 


### PR DESCRIPTION
## Summary

- `agents.spec.ts`: add 401 to `POST /api/agents/spawn`, `DELETE /api/agents/:id`, `GET /api/agents/health`, `GET /api/agents/:id/logs` — all send unauthenticated requests; server correctly returns 401 when auth is required
- `ws-relay.spec.ts`: add 401 to valid arrays for both WS upgrade tests — server may return 401 if the WS endpoint requires auth
- `user-mgmt-mh012.spec.ts`: no changes — all tests already properly authenticate with Bearer tokens

Fixes 261 test failures in CI where the server returned 401 but tests didn't include it as an acceptable code.

## Test plan

- [ ] `pnpm exec playwright test e2e/agents.spec.ts e2e/ws-relay.spec.ts` passes locally
- [ ] E2E CI job shows reduced failures (these 6 tests now accept 401)
- [ ] Verified docs/README are accurate after this change (no drift)

Closes #194