### PR TITLE
test(hive-web): add 401 to expected status codes in infrastructure.spec.ts

### DIFF
--- a/hive-web/e2e/infrastructure.spec.ts
+++ b/hive-web/e2e/infrastructure.spec.ts
@@ -32,7 +32,7 @@ test.describe('BE-003: WS Relay - Extended', () => {
   test('WS endpoint exists at /ws/:room_id', async ({ request }) => {
     // HTTP request to WS endpoint should return 426 Upgrade Required or 400
     const response = await request.get(`${API_URL}/ws/test-room`);
-    expect([400, 404, 426]).toContain(response.status());
+    expect([400, 401, 404, 426]).toContain(response.status());
   });
 });
 
@@ -55,6 +55,6 @@ test.describe('Negative Tests', () => {
       headers: { 'Content-Type': 'application/json' },
       data: '',
     });
-    expect([400, 404, 415, 422, 501]).toContain(response.status());
+    expect([400, 401, 404, 415, 422, 501]).toContain(response.status());
   });
 });


### PR DESCRIPTION
## Summary

- WS endpoint test: add 401 to `[400, 404, 426]` — server returns 401 when WebSocket upgrade request lacks auth
- Empty body POST test: add 401 to `[400, 404, 415, 422, 501]` — `/api/agents/spawn` returns 401 for unauthenticated requests
- `GET /api/health` already includes `daemon_connected` field (`main.rs:43`) — no server changes needed

## Test plan

- [ ] `pnpm exec playwright test e2e/infrastructure.spec.ts` passes locally
- [ ] Verified docs/README are accurate after this change (no drift)

Closes #223