### PR TITLE
feat(hive-web): add room-item and room-header testids (tb-169)

### DIFF
--- a/hive-web/src/App.tsx
+++ b/hive-web/src/App.tsx
@@ -543,7 +543,7 @@ function App() {
           {activeTab === "rooms" && selectedRoomId ? (
             <>
               {/* Room header */}
-              <div className="px-4 py-2 border-b border-gray-700 bg-gray-800 flex items-center justify-between">
+              <div data-testid="room-header" className="px-4 py-2 border-b border-gray-700 bg-gray-800 flex items-center justify-between">
                 <h2 className="text-sm font-semibold">
                   {rooms.find((r) => r.id === selectedRoomId)?.display_name ?? `#${selectedRoomId}`}
                 </h2>

--- a/hive-web/src/components/RoomList.tsx
+++ b/hive-web/src/components/RoomList.tsx
@@ -36,6 +36,7 @@ export function RoomList({ rooms, selectedRoomId, onSelectRoom, onCreateRoom }: 
       {rooms.map((room) => (
         <li key={room.id}>
           <button
+            data-testid="room-item"
             onClick={() => onSelectRoom(room.id)}
             className={`w-full text-left px-3 py-2 rounded text-sm transition-colors flex items-center justify-between ${
               selectedRoomId === room.id


### PR DESCRIPTION
Adds two missing `data-testid` attributes needed by Playwright e2e tests.

## Changes

- **`hive-web/src/components/RoomList.tsx`**: add `data-testid="room-item"` to the sidebar room button (each room row)
- **`hive-web/src/App.tsx`**: add `data-testid="room-header"` to the room header div in the main panel

## Why

`rooms.spec.ts` selects room rows with `[data-testid="room-item"]` and the room header with `[data-testid="room-header"]`. Without these attributes the tests fail immediately on selector lookup.

Closes #213
