### PR TITLE
test(hive-web): fix app-shell tests — auth mocks + tab data-testids

### DIFF
--- a/hive-web/src/App.tsx
+++ b/hive-web/src/App.tsx
@@ -433,6 +433,7 @@ function App() {
             onClick={() => setActiveTab(tab)}
             aria-selected={activeTab === tab}
             role="tab"
+            data-testid={`tab-${tab}`}
             className={`px-3 py-1.5 rounded text-sm font-medium capitalize transition-colors ${
               activeTab === tab
                 ? "bg-blue-600 text-white"

--- a/hive-web/tests/e2e/app-shell.spec.ts
+++ b/hive-web/tests/e2e/app-shell.spec.ts
@@ -2,10 +2,47 @@ import { test, expect } from '@playwright/test';
 
 /**
  * FE-001: App Shell with Three-Panel Layout and Tab Navigation
+ *
+ * Tests use a mock JWT token and mocked API routes — no running backend required.
  */
+
+// A mock JWT with admin role (payload: sub=1, username=admin, role=admin, exp=far future)
+const MOCK_TOKEN =
+  'eyJhbGciOiJIUzI1NiJ9.' +
+  btoa(JSON.stringify({ sub: '1', username: 'admin', role: 'admin', exp: 9999999999, iat: 1 }))
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_') +
+  '.mock-sig';
+
+/** Mount the app in an authenticated state with setup complete and no rooms. */
+async function setupPage(page: import('@playwright/test').Page) {
+  await page.addInitScript((token: string) => {
+    localStorage.setItem('hive-auth-token', token);
+  }, MOCK_TOKEN);
+
+  await page.route('**/api/setup/status', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ setup_complete: true, has_admin: true }),
+    }),
+  );
+
+  await page.route('**/api/rooms', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ rooms: [], total: 0 }),
+    }),
+  );
+
+  await page.goto('/');
+}
+
 test.describe('FE-001: App Shell Layout', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/');
+    await setupPage(page);
   });
 
   test('renders three-panel layout', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Add `setupPage` helper to `tests/e2e/app-shell.spec.ts` — sets mock JWT token, mocks `/api/setup/status` (returns `setup_complete: true`) and `/api/rooms` (returns empty list) so tests render past `SetupGuard` and `RequireAuth`
- Add `data-testid="tab-{name}"` to each tab button in `App.tsx` for reliable selector-based testing

## Root cause
`beforeEach` navigated to `/` without auth or setup mocks. `SetupGuard` fetches `/api/setup/status` before rendering children — without a mock it either hits a real backend (which may not be running) or fails, redirecting to `/setup` instead of rendering the app shell.

## Test plan
- [ ] `cargo test -p hive-server` passes
- [ ] `node_modules/.bin/tsc --noEmit` passes
- [ ] `pnpm build` succeeds
- [ ] `pnpm exec eslint src/` clean
- [ ] app-shell.spec.ts tests render the app shell with auth mocks

## Checklist
- [ ] CHANGELOG entry added under [Unreleased]
- [ ] Verified docs and README are accurate after this change (no drift)
- [ ] Test count did not decrease (or explained if it did)

## CHANGELOG
### Fixed
- `tests/e2e/app-shell.spec.ts` — add auth/setup mocks so tests render past `SetupGuard`; add `data-testid` to tab buttons in `App.tsx` (#199)

Closes #199