### PR TITLE
fix(hive-web): fix JWT auth setup in switch-rooms-mh017 spec (#216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - `playwright.config.ts` now uses `testMatch` covering both `./e2e/` and `./tests/e2e/` — 40 tests in `tests/e2e/` were previously orphaned and never run by CI (#173)
 - Replaced constant-value test assertions in `ws_relay.rs` and `rooms.rs` with behavior assertions; extracted `validate_description_len` helper from inline handler guard (#176)
+- `switch-rooms-mh017.spec.ts` test setup now uses a properly-formed JWT and stubs `/api/setup/status`, `/api/auth/me`, and `/api/rooms/*/members` — previously the plain-string mock token was rejected by `isTokenExpired()`, redirecting all tests to `/login` (#216)
 
 ### Added
 - `GET /api/users/me` endpoint — returns username, role, and ID from JWT claims (MH-011)

--- a/hive-web/e2e/switch-rooms-mh017.spec.ts
+++ b/hive-web/e2e/switch-rooms-mh017.spec.ts
@@ -10,7 +10,34 @@
 
 import { test, expect } from '@playwright/test';
 
-const MOCK_TOKEN = 'mock-jwt-token-mh017';
+// ---------------------------------------------------------------------------
+// JWT helper — produces a structurally valid JWT the client-side auth guard
+// accepts (checks format and exp claim only; signature is not verified).
+// ---------------------------------------------------------------------------
+
+function makeToken(opts: {
+  sub?: string;
+  username?: string;
+  role?: string;
+  exp?: number;
+} = {}): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(
+    JSON.stringify({
+      sub: opts.sub ?? '1',
+      username: opts.username ?? 'tester',
+      role: opts.role ?? 'user',
+      jti: 'mh017-test',
+      iat: 0,
+      exp: opts.exp ?? 9_999_999_999,
+    }),
+  ).toString('base64url');
+  return `${header}.${payload}.fake-sig`;
+}
+
+const MOCK_TOKEN = makeToken();
+
+const MOCK_USER = { sub: '1', username: 'tester', role: 'user', exp: 9_999_999_999 };
 
 const MOCK_ROOMS = [
   { id: 'general', name: 'general' },
@@ -26,6 +53,14 @@ async function setupAuthenticatedPage(page: import('@playwright/test').Page) {
   await page.addInitScript((token: string) => {
     localStorage.setItem('hive-auth-token', token);
   }, MOCK_TOKEN);
+
+  // Setup guard — must return setup_complete=true or the app redirects to /setup.
+  await page.route('**/api/setup/status', (route) =>
+    route.fulfill({ json: { setup_complete: true, has_admin: true } }),
+  );
+
+  // Auth background validation — must return 200 or AuthProvider logs the user out.
+  await page.route('**/api/auth/me', (route) => route.fulfill({ json: MOCK_USER }));
 
   await page.route('**/api/rooms', async (route) => {
     if (route.request().method() !== 'GET') {
@@ -46,6 +81,16 @@ async function setupAuthenticatedPage(page: import('@playwright/test').Page) {
       }),
     });
   });
+
+  // Members endpoint — called by App.tsx when a room is selected.
+  await page.route('**/api/rooms/*/members', (route) =>
+    route.fulfill({ json: { members: [] } }),
+  );
+
+  // Message history — called when entering a room.
+  await page.route('**/api/rooms/*/messages*', (route) =>
+    route.fulfill({ json: { messages: [], total: 0, has_more: false } }),
+  );
 
   // Block WebSocket upgrades — not needed for routing tests
   await page.route('**/ws/**', (route) => route.abort());
@@ -140,6 +185,17 @@ test.describe('MH-017: unread badge behaviour', () => {
     await page.addInitScript((token: string) => {
       localStorage.setItem('hive-auth-token', token);
     }, MOCK_TOKEN);
+
+    await page.route('**/api/setup/status', (route) =>
+      route.fulfill({ json: { setup_complete: true, has_admin: true } }),
+    );
+    await page.route('**/api/auth/me', (route) => route.fulfill({ json: MOCK_USER }));
+    await page.route('**/api/rooms/*/members', (route) =>
+      route.fulfill({ json: { members: [] } }),
+    );
+    await page.route('**/api/rooms/*/messages*', (route) =>
+      route.fulfill({ json: { messages: [], total: 0, has_more: false } }),
+    );
 
     // Return rooms with an unread count on 'general'
     await page.route('**/api/rooms', async (route) => {


### PR DESCRIPTION
## Summary
- Replace plain-string mock token with a properly-formed JWT in `switch-rooms-mh017.spec.ts` — `isTokenExpired()` was rejecting the old `'mock-jwt-token-mh017'` string and redirecting every test to `/login`
- Add `makeToken()` helper (base64url header.payload.sig format) matching what `decodeTokenPayload()` expects
- Add `page.route` stubs for `/api/setup/status`, `/api/auth/me`, and `/api/rooms/*/members` in `setupAuthenticatedPage` — all three are fetched by the app on load and were causing auth logouts or uncaught network errors in tests

## Root cause
`isTokenExpired()` calls `decodeTokenPayload()` which returns `null` for non-JWT strings, then treats a missing `exp` as expired. `computeInitialState()` then calls `clearToken()` and sets `isAuthenticated: false`, causing `RequireAuth` to redirect all tests to `/login` before they could interact with the room UI.

## Test plan
- [ ] All 14 tests in `switch-rooms-mh017.spec.ts` pass locally
- [ ] Docs/README accurate after this change (no drift)

Closes #216