### PR TITLE
test(hive-web): fix connection-status e2e — add setup/auth route mocks (tb-155)

### DIFF
--- a/hive-web/e2e/connection-status-mh026.spec.ts
+++ b/hive-web/e2e/connection-status-mh026.spec.ts
@@ -20,6 +20,28 @@ const MOCK_TOKEN =
   '.mock-sig';
 
 /**
+ * Mock SetupGuard's /api/setup/status and AuthProvider's /api/auth/me so
+ * tests do not depend on a running backend.  Call before page.goto().
+ */
+async function mockCommonRoutes(page: import('@playwright/test').Page) {
+  await page.route('**/api/setup/status', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ setup_complete: true, has_admin: true }),
+    }),
+  );
+
+  await page.route('**/api/auth/me', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ sub: '1', username: 'admin', role: 'admin' }),
+    }),
+  );
+}
+
+/**
  * Mount the app in a basic authenticated state with no rooms selected.
  * WebSocket is never actually opened since no room is selected.
  */
@@ -27,6 +49,8 @@ async function setupPage(page: import('@playwright/test').Page) {
   await page.addInitScript((token: string) => {
     localStorage.setItem('hive-auth-token', token);
   }, MOCK_TOKEN);
+
+  await mockCommonRoutes(page);
 
   await page.route('**/api/rooms', async (route) => {
     await route.fulfill({
@@ -86,6 +110,8 @@ test.describe('MH-026: connection status bar — disconnected state', () => {
       localStorage.setItem('hive-auth-token', token);
     }, MOCK_TOKEN);
 
+    await mockCommonRoutes(page);
+
     await page.route('**/api/rooms', async (route) => {
       if (route.request().method() === 'GET') {
         await route.fulfill({
@@ -120,6 +146,8 @@ test.describe('MH-026: connection status bar — reconnecting state', () => {
       localStorage.setItem('hive-auth-token', token);
     }, MOCK_TOKEN);
 
+    await mockCommonRoutes(page);
+
     await page.route('**/api/rooms', async (route) => {
       await route.fulfill({
         status: 200,
@@ -151,6 +179,8 @@ test.describe('MH-026: connection status bar — reconnecting state', () => {
       localStorage.setItem('hive-auth-token', token);
     }, MOCK_TOKEN);
 
+    await mockCommonRoutes(page);
+
     await page.route('**/api/rooms', async (route) => {
       await route.fulfill({
         status: 200,
@@ -174,6 +204,8 @@ test.describe('MH-026: connection status bar — reconnecting state', () => {
     await page.addInitScript((token: string) => {
       localStorage.setItem('hive-auth-token', token);
     }, MOCK_TOKEN);
+
+    await mockCommonRoutes(page);
 
     await page.route('**/api/rooms', async (route) => {
       await route.fulfill({


### PR DESCRIPTION
## Summary
- Add `mockCommonRoutes()` helper to `connection-status-mh026.spec.ts` that stubs `/api/setup/status` and `/api/auth/me`
- Update `setupPage()` to call `mockCommonRoutes()` so the base case always has the two required mocks
- Add `await mockCommonRoutes(page)` to the 4 inline test setups (reconnecting state tests + retry-button-not-visible test) that set up auth and navigate inline

Without these mocks, `SetupGuard` redirects to `/setup` and `AuthProvider` (which calls `/api/auth/me` on mount) may log the user out, so none of the connection-status assertions were reachable.

## CHANGELOG
### Fixed
- `e2e/connection-status-mh026.spec.ts`: add `/api/setup/status` and `/api/auth/me` route mocks so tests reach the connection-status UI without redirects (tb-155)

## Test plan
- [ ] `node_modules/.bin/tsc --noEmit` passes
- [ ] `pnpm build` succeeds
- [ ] `pnpm exec eslint src/` clean
- [ ] Playwright tests cover connection-status indicator visibility, states, tooltip, debounce, and retry button

## Checklist
- [ ] CHANGELOG entry added under [Unreleased]
- [ ] Verified docs and README are accurate after this change (no drift)
- [ ] Test count did not decrease (or explained if it did)