### PR TITLE
fix(hive-web): add auth setup to empty-states.spec.ts (tb-170)

### DIFF
--- a/hive-web/e2e/empty-states.spec.ts
+++ b/hive-web/e2e/empty-states.spec.ts
@@ -8,6 +8,39 @@
 import { test, expect } from '@playwright/test';
 
 // ---------------------------------------------------------------------------
+// Auth helpers
+// ---------------------------------------------------------------------------
+
+/** Fabricate a minimal JWT so RequireAuth passes without a real server. */
+function makeToken(): string {
+  const header = Buffer.from('{"alg":"HS256","typ":"JWT"}').toString('base64url');
+  const payload = Buffer.from(
+    JSON.stringify({ sub: '1', username: 'tester', role: 'admin', exp: Math.floor(Date.now() / 1000) + 3600 }),
+  ).toString('base64url');
+  return `${header}.${payload}.fake-signature`;
+}
+
+const TOKEN = makeToken();
+
+/**
+ * Inject auth token and stub /api/setup/status so SetupGuard passes.
+ * Must be called before page.goto() in every test.
+ */
+async function setupAuth(page: import('@playwright/test').Page) {
+  await page.addInitScript((tok) => {
+    localStorage.setItem('hive-auth-token', tok);
+  }, TOKEN);
+
+  await page.route('**/api/setup/status', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ setup_complete: true, has_admin: true }),
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -16,7 +49,7 @@ import { test, expect } from '@playwright/test';
  */
 async function mockEmptyRooms(page: import('@playwright/test').Page) {
   await page.route('**/api/rooms', (route) =>
-    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ rooms: [] }) }),
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ rooms: [], total: 0 }) }),
   );
 }
 
@@ -35,9 +68,10 @@ async function mockEmptyAgents(page: import('@playwright/test').Page) {
 
 test.describe('MH-005: Room list empty state', () => {
   test('shows "No rooms yet" empty state when room list is empty', async ({ page }) => {
+    await setupAuth(page);
     await mockEmptyRooms(page);
     await mockEmptyAgents(page);
-    await page.goto('/');
+    await page.goto('/rooms');
 
     const emptyState = page.getByTestId('room-list-empty');
     await expect(emptyState).toBeVisible();
@@ -45,33 +79,39 @@ test.describe('MH-005: Room list empty state', () => {
   });
 
   test('empty state includes guidance text', async ({ page }) => {
+    await setupAuth(page);
     await mockEmptyRooms(page);
     await mockEmptyAgents(page);
-    await page.goto('/');
+    await page.goto('/rooms');
 
     const emptyState = page.getByTestId('room-list-empty');
     await expect(emptyState).toContainText('Create your first room');
   });
 
   test('empty state has accessible role=status and aria-label', async ({ page }) => {
+    await setupAuth(page);
     await mockEmptyRooms(page);
     await mockEmptyAgents(page);
-    await page.goto('/');
+    await page.goto('/rooms');
 
     const emptyState = page.getByRole('status', { name: 'No rooms yet' });
     await expect(emptyState).toBeVisible();
   });
 
   test('room list does NOT show empty state when rooms exist', async ({ page }) => {
+    await setupAuth(page);
     await page.route('**/api/rooms', (route) =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ rooms: [{ id: 'room-dev', name: 'room-dev' }] }),
+        body: JSON.stringify({
+          rooms: [{ id: 'room-dev', name: 'room-dev', workspace_id: 1, workspace_name: 'default', added_at: new Date().toISOString() }],
+          total: 1,
+        }),
       }),
     );
     await mockEmptyAgents(page);
-    await page.goto('/');
+    await page.goto('/rooms');
 
     await expect(page.getByTestId('room-list-empty')).not.toBeVisible();
     await expect(page.getByText('#room-dev')).toBeVisible();
@@ -84,6 +124,7 @@ test.describe('MH-005: Room list empty state', () => {
 
 test.describe('MH-005: Agent grid empty state', () => {
   test('shows "No agents connected" empty state when agent list is empty', async ({ page }) => {
+    await setupAuth(page);
     await mockEmptyRooms(page);
     await mockEmptyAgents(page);
     await page.goto('/agents');
@@ -94,6 +135,7 @@ test.describe('MH-005: Agent grid empty state', () => {
   });
 
   test('agent empty state includes documentation link', async ({ page }) => {
+    await setupAuth(page);
     await mockEmptyRooms(page);
     await mockEmptyAgents(page);
     await page.goto('/agents');
@@ -105,6 +147,7 @@ test.describe('MH-005: Agent grid empty state', () => {
   });
 
   test('agent documentation link is keyboard-focusable', async ({ page }) => {
+    await setupAuth(page);
     await mockEmptyRooms(page);
     await mockEmptyAgents(page);
     await page.goto('/agents');
@@ -115,6 +158,7 @@ test.describe('MH-005: Agent grid empty state', () => {
   });
 
   test('agent grid does NOT show empty state when agents exist', async ({ page }) => {
+    await setupAuth(page);
     await mockEmptyRooms(page);
     await page.route('**/api/agents', (route) =>
       route.fulfill({
@@ -140,14 +184,15 @@ test.describe('MH-005: Agent grid empty state', () => {
 
 test.describe('MH-005: Loading state is visually distinct from empty state', () => {
   test('does not show empty state immediately — uses loading indicator first', async ({ page }) => {
+    await setupAuth(page);
     // Delay the API response by 500ms so we can catch the loading state
     await page.route('**/api/rooms', async (route) => {
       await new Promise((r) => setTimeout(r, 500));
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ rooms: [] }) });
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ rooms: [], total: 0 }) });
     });
     await mockEmptyAgents(page);
 
-    await page.goto('/');
+    await page.goto('/rooms');
 
     // During the delay the empty state should NOT yet be visible (skeleton/spinner shown instead)
     // The room list component does not have a loading skeleton yet, so we just verify the
@@ -156,10 +201,11 @@ test.describe('MH-005: Loading state is visually distinct from empty state', () 
     // The empty state renders immediately for RoomList since it has no loading state yet —
     // this test documents the current behaviour and will be updated when a skeleton is added.
     // For now we just assert the page does not crash.
-    await expect(page).toHaveURL('/');
+    await expect(page).toHaveURL('/rooms');
   });
 
   test('AgentGrid shows loading text before empty state appears', async ({ page }) => {
+    await setupAuth(page);
     await mockEmptyRooms(page);
     await page.route('**/api/agents', async (route) => {
       await new Promise((r) => setTimeout(r, 400));
@@ -182,6 +228,7 @@ test.describe('MH-005: Loading state is visually distinct from empty state', () 
 
 test.describe('MH-005: Daemon offline / error state', () => {
   test('AgentGrid shows connection error message when server is unreachable', async ({ page }) => {
+    await setupAuth(page);
     await mockEmptyRooms(page);
     // Abort network — simulates daemon being completely offline
     await page.route('**/api/agents', (route) => route.abort('connectionrefused'));


### PR DESCRIPTION
All empty-state `data-testid` attributes were already present in the components. The 11 tests in `empty-states.spec.ts` failed because the spec had no auth setup at all — no JWT token and no `/api/setup/status` mock, so `RequireAuth` and `SetupGuard` redirected every test to `/login` or `/setup` before any assertion ran.

## Changes

**`hive-web/e2e/empty-states.spec.ts`** (only file changed):
- Add `makeToken()` helper — proper base64url JWT accepted by `isTokenExpired()`
- Add `setupAuth()` function — injects token via `addInitScript` + stubs `/api/setup/status` returning `{setup_complete: true}`
- Call `setupAuth(page)` in every test before `page.goto()`
- Change `page.goto('/')` → `page.goto('/rooms')` for room-list tests (explicit tab URL)
- Add `total` field to `/api/rooms` mock responses (matches API contract)

No component changes required.

Closes #214
