### PR TITLE
test(hive-web): add missing testids to MessageBubble and fix chat-timeline spec auth (FE-004)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Fixed
+- `MessageBubble.tsx` — added `data-testid` attrs: `message`, `message-sender`, `message-content` on regular messages; `system-message` on join/leave/system/event rows (FE-004)
+- `tests/e2e/chat-timeline.spec.ts` — replaced unauthenticated `page.goto('/rooms')` shell with `setupPage()` helper (JWT injection, `/api/setup/status`, `/api/auth/me`, `/api/rooms` mocks) and rewrote tests to use strict `getByTestId` selectors (FE-004)
 - `playwright.config.ts` now uses `testMatch` covering both `./e2e/` and `./tests/e2e/` — 40 tests in `tests/e2e/` were previously orphaned and never run by CI (#173)
 - Replaced constant-value test assertions in `ws_relay.rs` and `rooms.rs` with behavior assertions; extracted `validate_description_len` helper from inline handler guard (#176)
 

--- a/hive-web/src/components/MessageBubble.tsx
+++ b/hive-web/src/components/MessageBubble.tsx
@@ -71,7 +71,10 @@ function SystemMessage({ message }: { message: RoomMessage }) {
         : (message.content ?? '');
 
   return (
-    <div className="flex items-start gap-2 px-4 py-1 text-xs text-gray-500">
+    <div
+      data-testid="system-message"
+      className="flex items-start gap-2 px-4 py-1 text-xs text-gray-500"
+    >
       <span className="w-5 text-center font-mono text-gray-600">{icon}</span>
       <span className="flex-1">
         [{formatRelative(message.ts)}] {text}
@@ -93,6 +96,7 @@ export default function MessageBubble({
 
   return (
     <div
+      data-testid="message"
       className={`flex items-start gap-3 px-4 hover:bg-gray-800/50 transition-colors ${
         isGrouped ? 'py-0.5' : 'py-2'
       }`}
@@ -110,7 +114,10 @@ export default function MessageBubble({
         {/* Header row — sender name + timestamp, suppressed for grouped messages */}
         {!isGrouped && (
           <div className="flex items-baseline gap-2">
-            <span className="font-semibold text-sm text-gray-100">
+            <span
+              data-testid="message-sender"
+              className="font-semibold text-sm text-gray-100"
+            >
               {message.user}
             </span>
             <span
@@ -124,7 +131,10 @@ export default function MessageBubble({
           </div>
         )}
 
-        <p className="text-sm text-gray-200 mt-0.5 break-words whitespace-pre-wrap">
+        <p
+          data-testid="message-content"
+          className="text-sm text-gray-200 mt-0.5 break-words whitespace-pre-wrap"
+        >
           {renderContent(message.content ?? '', currentUser)}
         </p>
       </div>

--- a/hive-web/tests/e2e/chat-timeline.spec.ts
+++ b/hive-web/tests/e2e/chat-timeline.spec.ts
@@ -1,52 +1,168 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 /**
  * FE-004: Chat Timeline with Real-Time Message Streaming
  */
-test.describe('FE-004: Chat Timeline', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/rooms');
+
+/** Build a valid JWT-format mock token (not verified by backend — frontend only checks expiry). */
+function makeToken(): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+  const payload = btoa(
+    JSON.stringify({
+      sub: '1',
+      username: 'testuser',
+      role: 'admin',
+      jti: 'fe004',
+      iat: 1700000000,
+      exp: 9999999999,
+    }),
+  )
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+  return `${header}.${payload}.MOCKSIG`;
+}
+
+const MOCK_TOKEN = makeToken();
+
+const MOCK_ROOMS = [
+  { id: 'general', name: 'general' },
+  { id: 'random', name: 'random' },
+];
+
+/** Set up common route mocks and inject auth token before navigation. */
+async function setupPage(page: Page) {
+  await page.addInitScript((token: string) => {
+    localStorage.setItem('hive-auth-token', token);
+    localStorage.setItem('hive-joined-rooms', 'general,random');
+  }, MOCK_TOKEN);
+
+  await page.route('**/api/setup/status', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ setup_complete: true }),
+    });
   });
 
+  await page.route('**/api/auth/me', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 1, username: 'testuser', role: 'admin' }),
+    });
+  });
+
+  await page.route('**/api/rooms', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ rooms: MOCK_ROOMS, total: MOCK_ROOMS.length }),
+    });
+  });
+
+  await page.route('**/api/rooms/*/members', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ members: [] }),
+    });
+  });
+
+  await page.route('**/api/rooms/*/messages', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ messages: [], has_more: false }),
+    });
+  });
+}
+
+test.describe('FE-004: Chat Timeline', () => {
   test('chat timeline renders in main content area', async ({ page }) => {
-    const timeline = page.locator('[data-testid="chat-timeline"], [class*="ChatTimeline"], [class*="timeline"]').first();
+    await setupPage(page);
+    await page.route('**/ws/**', (route) => route.abort());
+    await page.goto('/rooms/general');
+    const timeline = page.getByTestId('chat-timeline');
     await expect(timeline).toBeVisible();
   });
 
-  test('messages display sender, timestamp, and content', async ({ page }) => {
-    const messages = page.locator('[data-testid="message"], [class*="MessageBubble"], [class*="message-bubble"]');
-    const count = await messages.count();
-    if (count > 0) {
-      const firstMsg = messages.first();
-      // Should have username
-      const username = firstMsg.locator('[class*="username"], [class*="sender"], [data-testid="message-sender"]');
-      await expect(username).toBeVisible();
-      // Should have timestamp
-      const timestamp = firstMsg.locator('[class*="timestamp"], [class*="time"], time');
-      await expect(timestamp).toBeVisible();
-      // Should have content
-      const content = firstMsg.locator('[class*="content"], [data-testid="message-content"]');
-      await expect(content).toBeVisible();
-    }
+  test('data-testid="message" present on regular messages', async ({ page }) => {
+    await setupPage(page);
+
+    // Override messages mock to return one message
+    await page.route('**/api/rooms/general/messages', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          messages: [
+            {
+              type: 'message',
+              id: 'msg-001',
+              room: 'general',
+              user: 'alice',
+              ts: new Date().toISOString(),
+              content: 'Hello world',
+            },
+          ],
+          has_more: false,
+        }),
+      });
+    });
+
+    await page.route('**/ws/**', (route) => route.abort());
+    await page.goto('/rooms/general');
+    await page.waitForSelector('[data-testid="chat-timeline"]', { timeout: 5000 });
+
+    await expect(page.getByTestId('message').first()).toBeVisible();
+    await expect(page.getByTestId('message-sender').first()).toBeVisible();
+    await expect(page.getByTestId('message-content').first()).toBeVisible();
   });
 
-  test('system messages have distinct styling', async ({ page }) => {
-    const systemMsgs = page.locator('[data-testid="system-message"], [class*="system"]');
-    const count = await systemMsgs.count();
-    if (count > 0) {
-      const firstSys = systemMsgs.first();
-      // System messages should look different (muted styling)
-      await expect(firstSys).toBeVisible();
-    }
+  test('data-testid="system-message" present on system messages', async ({ page }) => {
+    await setupPage(page);
+
+    // Override messages mock to return a system message
+    await page.route('**/api/rooms/general/messages', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          messages: [
+            {
+              type: 'join',
+              id: 'sys-001',
+              room: 'general',
+              user: 'alice',
+              ts: new Date().toISOString(),
+            },
+          ],
+          has_more: false,
+        }),
+      });
+    });
+
+    await page.route('**/ws/**', (route) => route.abort());
+    await page.goto('/rooms/general');
+    await page.waitForSelector('[data-testid="chat-timeline"]', { timeout: 5000 });
+
+    await expect(page.getByTestId('system-message').first()).toBeVisible();
   });
 
-  test('new messages pill appears when scrolled up', async ({ page }) => {
-    const timeline = page.locator('[data-testid="chat-timeline"], [class*="ChatTimeline"], [class*="timeline"]').first();
-    // Scroll to top
-    await timeline.evaluate((el) => el.scrollTop = 0);
-    // Look for "new messages" indicator
-    const newMsgPill = page.locator('[data-testid="new-messages"], [class*="new-messages"], [class*="pill"]');
-    // This test validates the element exists in the DOM (may not be visible without new messages)
-    expect(newMsgPill).toBeDefined();
+  test('new messages badge hidden when at bottom', async ({ page }) => {
+    await setupPage(page);
+    await page.route('**/ws/**', (route) => route.abort());
+    await page.goto('/rooms/general');
+    await page.waitForSelector('[data-testid="chat-timeline"]', { timeout: 5000 });
+
+    await expect(page.getByTestId('new-messages-badge')).not.toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- Add  attrs to :  (wrapper),  (sender span),  (content paragraph),  (SystemMessage div)
- Rewrite : replace unauthenticated bare  with proper  helper — valid JWT injection, , ,  route mocks
- Replace lenient class-based fallback selectors with strict  assertions

## Test plan

- [ ]  — 4 tests: timeline visible, message/sender/content testids present, system-message testid present, badge hidden at bottom
- [ ]  — already passing (no changes, badge testid was already present)
- [ ] TypeScript:  passes
- [ ] Lint:  passes

## Docs

- [ ] Verified docs/README are accurate after this change (no drift)

Closes #207