### PR TITLE
fix(hive-web): rewrite logout UI tests with mocked routes (tb-176)

### DIFF
--- a/hive-web/e2e/logout-mh009.spec.ts
+++ b/hive-web/e2e/logout-mh009.spec.ts
@@ -7,7 +7,8 @@
  * - Clears local auth state
  * - Redirects to /login
  *
- * Requires the server running with HIVE_JWT_SECRET + HIVE_ADMIN_USER/PASSWORD.
+ * Backend API tests (request fixture) require a running server.
+ * UI tests use mocked routes — no live backend required.
  */
 
 import { test, expect } from '@playwright/test';
@@ -17,7 +18,7 @@ const ADMIN_USER = process.env.HIVE_ADMIN_USER || 'admin';
 const ADMIN_PASSWORD = process.env.HIVE_ADMIN_PASSWORD || 'test-password';
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Helpers — backend API tests
 // ---------------------------------------------------------------------------
 
 async function loginAsAdmin(
@@ -30,6 +31,67 @@ async function loginAsAdmin(
   const { token } = await res.json();
   expect(typeof token).toBe('string');
   return token as string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — UI tests (mocked, no live backend required)
+// ---------------------------------------------------------------------------
+
+/** Fabricate a minimal JWT so RequireAuth passes without a real server. */
+function makeToken(): string {
+  const header = Buffer.from('{"alg":"HS256","typ":"JWT"}').toString('base64url');
+  const payload = Buffer.from(
+    JSON.stringify({ sub: '1', username: 'admin', role: 'admin', exp: Math.floor(Date.now() / 1000) + 3600 }),
+  ).toString('base64url');
+  return `${header}.${payload}.fake-signature`;
+}
+
+const MOCK_TOKEN = makeToken();
+
+/**
+ * Set up the page for UI logout tests:
+ * - Inject a valid mock JWT into localStorage
+ * - Stub /api/setup/status so SetupGuard passes
+ * - Stub /api/rooms so the rooms tab renders
+ * - Stub /api/auth/me so auth refreshes don't clear the token
+ * - Stub POST /api/auth/logout to return 200
+ */
+async function setupPage(page: import('@playwright/test').Page) {
+  await page.addInitScript((tok) => {
+    localStorage.setItem('hive-auth-token', tok);
+  }, MOCK_TOKEN);
+
+  await page.route('**/api/setup/status', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ setup_complete: true, has_admin: true }),
+    }),
+  );
+
+  await page.route('**/api/rooms', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ rooms: [], total: 0 }),
+    }),
+  );
+
+  await page.route('**/api/auth/me', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ sub: '1', username: 'admin', role: 'admin' }),
+    }),
+  );
+
+  await page.route('**/api/auth/logout', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ message: 'logged out successfully' }),
+    }),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -107,28 +169,26 @@ test.describe('MH-009: POST /api/auth/logout — auth required', () => {
 });
 
 // ---------------------------------------------------------------------------
-// AC: UI — logout button clears token and redirects (browser tests)
+// AC: UI — logout button clears token and redirects (browser tests, mocked)
 // ---------------------------------------------------------------------------
 
 test.describe('MH-009: logout UI', () => {
-  test.beforeEach(async ({ page, request }) => {
-    // Seed localStorage with a valid token before navigating to the app.
-    const token = await loginAsAdmin({ request });
-    await page.goto(`${process.env.HIVE_WEB_URL || 'http://localhost:5173'}/`);
-    await page.evaluate((t) => localStorage.setItem('hive-auth-token', t), token);
-    await page.reload();
-  });
-
   test('logout button is visible in the top nav', async ({ page }) => {
+    await setupPage(page);
+    await page.goto('/rooms');
     await expect(page.getByTestId('logout-button')).toBeVisible();
   });
 
   test('clicking logout redirects to /login', async ({ page }) => {
+    await setupPage(page);
+    await page.goto('/rooms');
     await page.getByTestId('logout-button').click();
     await expect(page).toHaveURL(/\/login/);
   });
 
   test('local storage token is cleared after logout', async ({ page }) => {
+    await setupPage(page);
+    await page.goto('/rooms');
     await page.getByTestId('logout-button').click();
     await page.waitForURL(/\/login/);
     const token = await page.evaluate(() => localStorage.getItem('hive-auth-token'));
@@ -136,9 +196,11 @@ test.describe('MH-009: logout UI', () => {
   });
 
   test('navigating to protected route after logout redirects to /login', async ({ page }) => {
+    await setupPage(page);
+    await page.goto('/rooms');
     await page.getByTestId('logout-button').click();
     await page.waitForURL(/\/login/);
-    await page.goto(`${process.env.HIVE_WEB_URL || 'http://localhost:5173'}/rooms`);
+    await page.goto('/rooms');
     await expect(page).toHaveURL(/\/login/);
   });
 });


### PR DESCRIPTION
The 4 UI tests in `logout-mh009.spec.ts` used `loginAsAdmin()` to get a real server token, then reloaded the page. `SetupGuard` calls `GET /api/setup/status` on every page load — on a fresh server `seed_admin_user()` only creates the admin user, it does NOT set `setup_complete=true`. This caused `SetupGuard` to redirect every UI test to `/setup` before any assertion ran.

## Changes

**`hive-web/e2e/logout-mh009.spec.ts`**:
- Add `makeToken()` helper (proper base64url JWT)
- Add `setupPage()` — stubs `/api/setup/status` (`setup_complete: true`), `/api/rooms`, `/api/auth/me`, and `POST /api/auth/logout`
- Replace `test.beforeEach` (which used `loginAsAdmin()`) with per-test `setupPage(page)` calls + `page.goto('/rooms')`
- Remove `HIVE_WEB_URL` references — use relative paths with Playwright's `baseURL`

**Backend API tests unchanged** — the 5 tests using `request` fixture test real token revocation behavior and work correctly with the live backend.

Closes #218
