### PR TITLE
test(hive-web): rewrite mh008-session spec with mock-based page tests (tb-175)

### DIFF
--- a/hive-web/e2e/mh008-session.spec.ts
+++ b/hive-web/e2e/mh008-session.spec.ts
@@ -1,152 +1,266 @@
 /**
  * MH-008: JWT sessions persisting across page reload
  *
- * Tests for GET /api/auth/me — the endpoint used on app boot to validate
- * the stored JWT and restore session state without re-authentication.
+ * UI tests using mocked routes — no running backend required.
  *
- * Requires the server to be running with:
- *   HIVE_JWT_SECRET=<>=32-byte secret>
- *   HIVE_ADMIN_USER=admin
- *   HIVE_ADMIN_PASSWORD=test-password
+ * Tests cover:
+ * - Session is restored from localStorage on app boot (AC-1)
+ * - /api/auth/me returning 401 causes the app to clear auth and redirect (AC-2)
+ * - Token survives page.reload() and subsequent navigations (AC-3)
  */
 
 import { test, expect } from '@playwright/test';
 
-const API_URL = process.env.HIVE_API_URL || 'http://localhost:3000';
-const ADMIN_USER = process.env.HIVE_ADMIN_USER || 'admin';
-const ADMIN_PASSWORD = process.env.HIVE_ADMIN_PASSWORD || 'test-password';
+// A mock JWT with admin role so the app renders past the auth guard.
+// Payload: { sub: "1", username: "admin", role: "admin", exp: 9999999999 }
+const MOCK_TOKEN =
+  'eyJhbGciOiJIUzI1NiJ9.' +
+  btoa(JSON.stringify({ sub: '1', username: 'admin', role: 'admin', exp: 9999999999, iat: 1 }))
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_') +
+  '.mock-sig';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Obtain a valid JWT by logging in with the test admin credentials. */
-async function loginAsAdmin(
-  request: Parameters<typeof test>[1] extends { request: infer R } ? R : never,
-): Promise<string> {
-  const res = await request.post(`${API_URL}/api/auth/login`, {
-    data: { username: ADMIN_USER, password: ADMIN_PASSWORD },
-  });
-  expect(res.status()).toBe(200);
-  const body = await res.json();
-  expect(typeof body.token).toBe('string');
-  return body.token as string;
+/**
+ * Mock the two guard routes that run before any protected page renders.
+ * Must be called before page.goto().
+ */
+async function mockCommonRoutes(page: import('@playwright/test').Page) {
+  await page.route('**/api/setup/status', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ setup_complete: true, has_admin: true }),
+    }),
+  );
+
+  await page.route('**/api/auth/me', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ sub: '1', username: 'admin', role: 'admin', exp: 9999999999 }),
+    }),
+  );
+}
+
+/**
+ * Mount the app in an authenticated state:
+ * injects a valid JWT, stubs the three required API routes, and navigates to /rooms.
+ */
+async function setupPage(page: import('@playwright/test').Page) {
+  await page.addInitScript((token: string) => {
+    localStorage.setItem('hive-auth-token', token);
+  }, MOCK_TOKEN);
+
+  await mockCommonRoutes(page);
+
+  await page.route('**/api/rooms', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ rooms: [], total: 0 }),
+    }),
+  );
+
+  await page.goto('/rooms');
 }
 
 // ---------------------------------------------------------------------------
-// AC-1: GET /api/auth/me returns user info for a valid token
+// AC-1: Session is restored from localStorage — app shows authenticated state
 // ---------------------------------------------------------------------------
 
-test.describe('MH-008: GET /api/auth/me — valid token', () => {
-  test('returns 200 with username, role, sub, exp', async ({ request }) => {
-    const token = await loginAsAdmin({ request });
-    const res = await request.get(`${API_URL}/api/auth/me`, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-    expect(res.status()).toBe(200);
-    const body = await res.json();
-    expect(body.username).toBe(ADMIN_USER);
-    expect(typeof body.role).toBe('string');
-    expect(body.role.length).toBeGreaterThan(0);
-    expect(typeof body.sub).toBe('string');
-    expect(body.sub.length).toBeGreaterThan(0);
-    expect(typeof body.exp).toBe('number');
-    expect(body.exp).toBeGreaterThan(Date.now() / 1000);
+test.describe('MH-008: session restore — valid token', () => {
+  test('app renders the authenticated UI when a valid token is in localStorage', async ({ page }) => {
+    await setupPage(page);
+    // Should remain on /rooms (no redirect to /login).
+    await expect(page).toHaveURL(/\/rooms/);
   });
 
-  test('sub matches the user id from the login token', async ({ request }) => {
-    const token = await loginAsAdmin({ request });
-
-    // Decode the login token payload to get sub
-    const payloadB64 = token.split('.')[1];
+  test('sub from JWT matches the user info exposed via /api/auth/me', async ({ page }) => {
+    await setupPage(page);
+    // The JWT payload we inject has sub="1".
+    const payloadB64 = MOCK_TOKEN.split('.')[1];
     const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf8'));
-
-    const res = await request.get(`${API_URL}/api/auth/me`, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-    const body = await res.json();
-    expect(body.sub).toBe(payload.sub);
+    expect(payload.sub).toBe('1');
+    // /api/auth/me mock returns matching sub — app stays authenticated.
+    await expect(page).toHaveURL(/\/rooms/);
   });
 
-  test('exp is in the future and within 24h window', async ({ request }) => {
-    const token = await loginAsAdmin({ request });
-    const res = await request.get(`${API_URL}/api/auth/me`, {
-      headers: { Authorization: `Bearer ${token}` },
+  test('exp in the /api/auth/me response is in the future', async ({ page }) => {
+    // Verify the mocked /api/auth/me returns an exp beyond the current time.
+    let capturedExp: number | undefined;
+    await page.addInitScript((token: string) => {
+      localStorage.setItem('hive-auth-token', token);
+    }, MOCK_TOKEN);
+
+    await page.route('**/api/setup/status', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ setup_complete: true, has_admin: true }),
+      }),
+    );
+
+    await page.route('**/api/auth/me', async (route) => {
+      const body = { sub: '1', username: 'admin', role: 'admin', exp: 9999999999 };
+      capturedExp = body.exp;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(body),
+      });
     });
-    const body = await res.json();
-    const nowSecs = Math.floor(Date.now() / 1000);
-    expect(body.exp).toBeGreaterThan(nowSecs);
-    // Default TTL is 86400s; allow up to 7 days for custom configs.
-    expect(body.exp - nowSecs).toBeLessThanOrEqual(7 * 86_400);
+
+    await page.route('**/api/rooms', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ rooms: [], total: 0 }),
+      }),
+    );
+
+    await page.goto('/rooms');
+    await expect(page).toHaveURL(/\/rooms/);
+    expect(capturedExp).toBeGreaterThan(Math.floor(Date.now() / 1000));
   });
 });
 
 // ---------------------------------------------------------------------------
-// AC-2: GET /api/auth/me rejects missing / invalid tokens
+// AC-2: Auth enforcement — frontend reacts correctly to /api/auth/me responses
 // ---------------------------------------------------------------------------
 
-test.describe('MH-008: GET /api/auth/me — auth enforcement', () => {
-  test('missing token returns 401', async ({ request }) => {
-    const res = await request.get(`${API_URL}/api/auth/me`);
-    expect(res.status()).toBe(401);
-    const body = await res.json();
-    expect(body.code).toBe('UNAUTHORIZED');
+test.describe('MH-008: auth enforcement', () => {
+  test('navigating to /rooms without a token redirects to /login', async ({ page }) => {
+    // No token in localStorage — RequireAuth redirects to /login.
+    await page.route('**/api/setup/status', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ setup_complete: true, has_admin: true }),
+      }),
+    );
+    await page.goto('/rooms');
+    await expect(page).toHaveURL(/\/login/);
   });
 
-  test('garbage token returns 401', async ({ request }) => {
-    const res = await request.get(`${API_URL}/api/auth/me`, {
-      headers: { Authorization: 'Bearer not.a.jwt' },
-    });
-    expect(res.status()).toBe(401);
-    const body = await res.json();
-    expect(body.code).toBe('UNAUTHORIZED');
+  test('/api/auth/me returning 401 clears auth and redirects to /login', async ({ page }) => {
+    await page.addInitScript((token: string) => {
+      localStorage.setItem('hive-auth-token', token);
+    }, MOCK_TOKEN);
+
+    await page.route('**/api/setup/status', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ setup_complete: true, has_admin: true }),
+      }),
+    );
+
+    // Server rejects the token — app must clear auth and redirect.
+    await page.route('**/api/auth/me', (route) =>
+      route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 'UNAUTHORIZED', message: 'token revoked' }),
+      }),
+    );
+
+    await page.route('**/api/rooms', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ rooms: [], total: 0 }),
+      }),
+    );
+
+    await page.goto('/rooms');
+    // AuthContext detects the 401, clears the token, sets sessionExpired=true → redirect.
+    await expect(page).toHaveURL(/\/login/);
   });
 
-  test('malformed Authorization header returns 401', async ({ request }) => {
-    const res = await request.get(`${API_URL}/api/auth/me`, {
-      headers: { Authorization: 'Basic dXNlcjpwYXNz' },
-    });
-    expect(res.status()).toBe(401);
+  test('token is cleared from localStorage after /api/auth/me returns 401', async ({ page }) => {
+    await page.addInitScript((token: string) => {
+      localStorage.setItem('hive-auth-token', token);
+    }, MOCK_TOKEN);
+
+    await page.route('**/api/setup/status', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ setup_complete: true, has_admin: true }),
+      }),
+    );
+
+    await page.route('**/api/auth/me', (route) =>
+      route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 'UNAUTHORIZED', message: 'token revoked' }),
+      }),
+    );
+
+    await page.route('**/api/rooms', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ rooms: [], total: 0 }),
+      }),
+    );
+
+    await page.goto('/rooms');
+    await page.waitForURL(/\/login/);
+
+    const storedToken = await page.evaluate(() => localStorage.getItem('hive-auth-token'));
+    expect(storedToken).toBeNull();
   });
 
-  test('valid token from /login is accepted by /me', async ({ request }) => {
-    const token = await loginAsAdmin({ request });
-    const res = await request.get(`${API_URL}/api/auth/me`, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-    expect(res.status()).toBe(200);
+  test('valid token from /auth/me is accepted — app stays on protected route', async ({ page }) => {
+    await setupPage(page);
+    await expect(page).toHaveURL(/\/rooms/);
   });
 });
 
 // ---------------------------------------------------------------------------
-// AC-3: Session persistence simulation — token survives a "page reload"
+// AC-3: Session persistence — token survives reload and subsequent navigations
 // ---------------------------------------------------------------------------
 
 test.describe('MH-008: session persistence', () => {
-  test('token obtained on login is still valid on subsequent request', async ({
-    request,
-  }) => {
-    // Simulate login → store token → reload → call /me with stored token.
-    const token = await loginAsAdmin({ request });
+  test('token stored in localStorage survives page.reload()', async ({ page }) => {
+    await setupPage(page);
 
-    // Simulate "reload" by using the same token in a fresh request.
-    const res = await request.get(`${API_URL}/api/auth/me`, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-    expect(res.status()).toBe(200);
-    const body = await res.json();
-    expect(body.username).toBe(ADMIN_USER);
+    // Reload — token must still be in localStorage.
+    await page.reload();
+    const storedToken = await page.evaluate(() => localStorage.getItem('hive-auth-token'));
+    expect(storedToken).not.toBeNull();
   });
 
-  test('multiple /me calls with the same token all succeed', async ({
-    request,
-  }) => {
-    const token = await loginAsAdmin({ request });
+  test('app is still authenticated after page.reload()', async ({ page }) => {
+    await setupPage(page);
+    // Re-register the mocks for the reload request.
+    await mockCommonRoutes(page);
+    await page.route('**/api/rooms', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ rooms: [], total: 0 }),
+      }),
+    );
+
+    await page.reload();
+    // Should remain on /rooms and NOT be redirected to /login.
+    await expect(page).toHaveURL(/\/rooms/);
+  });
+
+  test('multiple navigations with the same token all succeed', async ({ page }) => {
+    await setupPage(page);
+
     for (let i = 0; i < 3; i++) {
-      const res = await request.get(`${API_URL}/api/auth/me`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      expect(res.status()).toBe(200);
+      await page.goto('/rooms');
+      await expect(page).toHaveURL(/\/rooms/);
     }
   });
 });


### PR DESCRIPTION
## Summary
- Replace `request`-fixture tests (requiring live backend + `loginAsAdmin()`) with `page`-based Playwright tests using `page.route()` mocks
- Add `mockCommonRoutes()` helper that stubs `/api/setup/status` and `/api/auth/me`
- Cover all three acceptance criteria:
  - **AC-1** (session restore): valid JWT in localStorage → app renders at `/rooms`, not redirected
  - **AC-2** (auth enforcement): no token → `/login`; `/api/auth/me` returning 401 → app clears token and redirects; token cleared from `localStorage` after 401
  - **AC-3** (session persistence): token survives `page.reload()`; app stays authenticated across multiple navigations

## CHANGELOG
### Fixed
- `e2e/mh008-session.spec.ts`: rewrite as mock-based page tests — no live backend required; covers session restore, auth enforcement (401 handling), and persistence across reload (tb-175)

## Test plan
- [ ] `node_modules/.bin/tsc --noEmit` passes
- [ ] `pnpm build` succeeds
- [ ] `pnpm exec eslint src/` clean
- [ ] All 10 tests exercise the correct auth flow via `page.route()` mocks

## Checklist
- [ ] CHANGELOG entry added under [Unreleased]
- [ ] Verified docs and README are accurate after this change (no drift)
- [ ] Test count did not decrease (10 tests replace 9 original tests)