### PR TITLE
fix(hive-server): validate content field in POST /api/rooms/:id/send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - `playwright.config.ts` now uses `testMatch` covering both `./e2e/` and `./tests/e2e/` — 40 tests in `tests/e2e/` were previously orphaned and never run by CI (#173)
 - Replaced constant-value test assertions in `ws_relay.rs` and `rooms.rs` with behavior assertions; extracted `validate_description_len` helper from inline handler guard (#176)
+- `POST /api/rooms/:id/send` now validates the request body before proxying — returns 400 when `content` is absent or empty instead of forwarding an invalid payload to the daemon (#220)
 
 ### Added
 - `GET /api/users/me` endpoint — returns username, role, and ID from JWT claims (MH-011)

--- a/crates/hive-server/src/rest_proxy.rs
+++ b/crates/hive-server/src/rest_proxy.rs
@@ -175,6 +175,16 @@ pub async fn get_messages(
     }))
 }
 
+/// Validate that the `content` field in a send-message body is a non-empty
+/// string. Returns `Err(BAD_REQUEST)` if missing or empty so the proxy never
+/// forwards invalid payloads to the daemon.
+fn validate_send_body(body: &Value) -> Result<(), StatusCode> {
+    match body.get("content").and_then(Value::as_str) {
+        Some(s) if !s.is_empty() => Ok(()),
+        _ => Err(StatusCode::BAD_REQUEST),
+    }
+}
+
 /// POST /api/rooms/:room_id/send — send a message to a room.
 pub async fn send_message(
     State(state): State<Arc<AppState>>,
@@ -182,6 +192,8 @@ pub async fn send_message(
     headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> Result<Json<Value>, StatusCode> {
+    validate_send_body(&body)?;
+
     let base = daemon_base(&state);
     let url = format!("{base}/api/{room_id}/send");
 
@@ -298,5 +310,52 @@ mod tests {
         let (page, has_more) = paginate(&msgs, None, 50);
         assert_eq!(page.len(), 5);
         assert!(!has_more);
+    }
+
+    // -----------------------------------------------------------------------
+    // validate_send_body tests (MH-021)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn send_body_valid_content_accepted() {
+        assert!(validate_send_body(&json!({"content": "hello"})).is_ok());
+    }
+
+    #[test]
+    fn send_body_unicode_content_accepted() {
+        assert!(validate_send_body(&json!({"content": "日本語 🎉"})).is_ok());
+    }
+
+    #[test]
+    fn send_body_missing_content_rejected() {
+        assert_eq!(
+            validate_send_body(&json!({})),
+            Err(StatusCode::BAD_REQUEST)
+        );
+    }
+
+    #[test]
+    fn send_body_empty_content_rejected() {
+        assert_eq!(
+            validate_send_body(&json!({"content": ""})),
+            Err(StatusCode::BAD_REQUEST)
+        );
+    }
+
+    #[test]
+    fn send_body_non_string_content_rejected() {
+        assert_eq!(
+            validate_send_body(&json!({"content": 42})),
+            Err(StatusCode::BAD_REQUEST)
+        );
+        assert_eq!(
+            validate_send_body(&json!({"content": null})),
+            Err(StatusCode::BAD_REQUEST)
+        );
+    }
+
+    #[test]
+    fn send_body_extra_fields_do_not_affect_validation() {
+        assert!(validate_send_body(&json!({"content": "hi", "room_id": "test", "user": "alice"})).is_ok());
     }
 }


### PR DESCRIPTION
## Summary

`send_message()` in `rest_proxy.rs` forwarded any payload to the daemon without validating the request body. When the daemon was unavailable it returned 502; when up it forwarded empty/missing content without error. The validation tests in `mh021-send-message.spec.ts` expect 400/422 for missing or empty `content`.

- Add `validate_send_body()` — checks `body["content"]` is a non-empty string, returns `400 BAD_REQUEST` before the daemon proxy is reached
- This keeps validation at the hive-server boundary regardless of daemon availability
- Add 6 unit tests: valid content, unicode, missing field, empty string, non-string types (int, null), extra fields ignored

## Test plan

- [ ] `cargo test -p hive-server` passes (177 tests, 6 new validation tests)
- [ ] `POST /api/rooms/:id/send` with no `content` → 400
- [ ] `POST /api/rooms/:id/send` with empty `content` → 400
- [ ] `POST /api/rooms/:id/send` with valid `content` → proxied to daemon (200/502 depending on daemon state)
- [ ] Auth enforcement unchanged (middleware layer, not affected)

## Docs

- [ ] Verified docs/README are accurate after this change (no drift)

Closes #220