### PR TITLE
test(hive-web): fix mh027-ws-reconnect spec — correct setup/status mock (tb-179)

### DIFF
--- a/hive-web/e2e/mh027-ws-reconnect.spec.ts
+++ b/hive-web/e2e/mh027-ws-reconnect.spec.ts
@@ -57,7 +57,7 @@ async function setupPage(page: import('@playwright/test').Page) {
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ complete: true }),
+      body: JSON.stringify({ setup_complete: true, has_admin: true }),
     }),
   );
 


### PR DESCRIPTION
## Summary
- Fix `/api/setup/status` mock in `mh027-ws-reconnect.spec.ts`: was returning `{ complete: true }` but `SetupGuard` checks `data.setup_complete` — all tests were redirecting to `/setup`
- Change mock to `{ setup_complete: true, has_admin: true }` (consistent with every other spec in this sprint)

## Root cause
`SetupGuard` uses `data.setup_complete` (line 44 of `SetupGuard.tsx`). The mock had a typo: `complete` instead of `setup_complete`, causing a silent redirect to `/setup` before any assertion ran.

## CHANGELOG
### Fixed
- `e2e/mh027-ws-reconnect.spec.ts`: correct `/api/setup/status` mock — `{ complete: true }` → `{ setup_complete: true, has_admin: true }` so `SetupGuard` does not redirect tests to `/setup` (tb-179)

## Test plan
- [ ] `node_modules/.bin/tsc --noEmit` passes
- [ ] `pnpm build` succeeds
- [ ] `pnpm exec eslint src/` clean

## Checklist
- [ ] CHANGELOG entry added under [Unreleased]
- [ ] Verified docs and README are accurate after this change (no drift)
- [ ] Test count did not decrease (no test count change — single mock value fix)